### PR TITLE
Full predicted lDDT

### DIFF
--- a/webfront/README.md
+++ b/webfront/README.md
@@ -3,7 +3,7 @@ Developers Documentation
 
 This API was developed using [Django REST Framework](http://www.django-rest-framework.org/), but we have adapted it for our needs.
 
-You can read about the deatils of the chaanges in each of the parts of the framework:
+You can read about the details of the changes in each of the parts of the framework:
 
 * [Views](./views/README.md)
 * [Queryset](./views/QUERYSET_README.md)

--- a/webfront/models/interpro_new.py
+++ b/webfront/models/interpro_new.py
@@ -234,7 +234,7 @@ class StructuralModel(models.Model):
     accession = models.CharField(max_length=25, null=False)
     contacts = models.BinaryField()
     structure = models.BinaryField()
-    lddt = models.FloatField()
+    lddt = models.BinaryField()
 
     class Meta:
         db_table = "webfront_structuralmodel"

--- a/webfront/tests/README.md
+++ b/webfront/tests/README.md
@@ -23,7 +23,9 @@ This in an example of how to generate the fixtures file for `StructuralModel`. T
     ATOM      4  O   VAL A   1       0.991   2.879  -0.532  1.00  4.92           O   
     """  
     structure_gz = gzip.compress(bytes(structure,'utf-8'))
-    model = StructuralModel(model_id=1,accession='PF17176',contacts=contacts_gz,structure=structure_gz)
+    lddt = '[0.07427680118058666, 0.016404920747420615, 0.5094414232300765]'
+    lddt_gz = gzip.compress(bytes(lddt,'utf-8'))
+    model = StructuralModel(model_id=1,accession='PF17176',contacts=contacts_gz,structure=structure_gz,lddt=lddt_gz)
    
     model.save()
     ```

--- a/webfront/tests/fixtures_structure.json
+++ b/webfront/tests/fixtures_structure.json
@@ -222,11 +222,10 @@
     "model": "webfront.structuralmodel",
     "pk": 1,
     "fields": {
-        "accession": "PF17176",
-        "lddt": 0.5,
-        "contacts": "H4sIAOAnHWAC/4uONtQxNNQx0DON1VGINtIxNgCyLUBsYxg7FgCIHLXIJAAAAA==",
-        "structure": "H4sIAOcnHWAC/42QMQ7DMAhF95yCCxRhOy54RFnbZIly/6MEcBWpSi2V5X9s/Qe27tsbohLAanLoC7S3Xg9CJvcJmSm0tOxC1s3o/irLT3oB7WbRGxAIn819Rqq5g5MMgMsXsMTBDWgbyRxAEeoDCv8FtNQGvzZsnw2FW3xBLaMnW346Aa6DA5lEAQAA"
+      "accession": "PF17176",
+      "contacts": "H4sIAB6Io2AC/4uONtQxNNQx0DON1VGINtIxNgCyLUBsYxg7FgCIHLXIJAAAAA==",
+      "structure": "H4sIAB6Io2AC/42QQQ6EIAxF956iF5imgNiybNyqbIz3P4otTExmHJPp5v9C/mtB97pCqwCwmRy6gPbW60XI5D4gMzVNJbqQdSO6v8rzg15Eu5r1RgTCqbiPSDl2cpAH4vxJTP3km2g7ydiIItQnJP6PaLEKv3Ys7x2FS/uFnJ5e7fnhBOGGnjRIAQAA",
+      "lddt": "H4sIAB6Io2AC/xXJwQ2AMAwDwFUYACE7dZx0FsT+azR87148KEW5QTaybd/XIC1ox+Q0zPw1sSUqViygnN8BxhV43z8AAAA="
     }
   }
-
 ]

--- a/webfront/tests/tests_modifiers.py
+++ b/webfront/tests/tests_modifiers.py
@@ -459,13 +459,6 @@ class ResidueModifierTest(InterproRESTTestCase):
 
 
 class StructuralModelTest(InterproRESTTestCase):
-    def test_model_info_modifier(self):
-        response = self.client.get("/api/entry/pfam/PF17176?model:info")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("accession", response.data)
-        self.assertIn("lddt", response.data)
-        self.assertEqual(0.5, response.data["lddt"])
-
     def test_model_structure_modifier(self):
         response = self.client.get("/api/entry/pfam/PF17176?model:structure")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -483,3 +476,13 @@ class StructuralModelTest(InterproRESTTestCase):
         data = json.loads(content)
         self.assertEqual(3, len(data))
         self.assertEqual(3, len(data[0]))
+
+    def test_model_lddt_modifier(self):
+        response = self.client.get("/api/entry/pfam/PF17176?model:lddt")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.charset, "utf-8")
+        self.assertEqual(response["content-type"], "application/json")
+        content = gzip.decompress(response.content)
+        data = json.loads(content)
+        self.assertEqual(3, len(data))
+        self.assertTrue(all([0 <= item <= 1 for item in data]))

--- a/webfront/views/entry.py
+++ b/webfront/views/entry.py
@@ -51,9 +51,6 @@ class MemberAccessionHandler(CustomView):
         )
 
         general_handler.modifiers.register(
-            "model:info", get_model("info"), type=ModifierType.REPLACE_PAYLOAD
-        )
-        general_handler.modifiers.register(
             "model:structure",
             get_model("structure"),
             type=ModifierType.REPLACE_PAYLOAD,
@@ -62,6 +59,12 @@ class MemberAccessionHandler(CustomView):
         general_handler.modifiers.register(
             "model:contacts",
             get_model("contacts"),
+            type=ModifierType.REPLACE_PAYLOAD,
+            serializer=SerializerDetail.ANNOTATION_BLOB,
+        )
+        general_handler.modifiers.register(
+            "model:lddt",
+            get_model("lddt"),
             type=ModifierType.REPLACE_PAYLOAD,
             serializer=SerializerDetail.ANNOTATION_BLOB,
         )

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -826,17 +826,21 @@ def get_model(type):
             raise EmptyQuerysetError("The selected entry doesn't have a linked model")
 
         annotation = queryset.first()
-        if type == "info":
-            return {"lddt": annotation.lddt, "accession": annotation.accession}
+
         payload = lambda: None
         payload.accession = annotation.accession
         payload.type = "model:pdb"
+
         if type == "structure":
             payload.mime_type = "chemical/x-pdb"
             payload.value = annotation.structure
         elif type == "contacts":
             payload.mime_type = "application/json"
             payload.value = annotation.contacts
+        elif type == "lddt":
+            payload.mime_type = "application/json"
+            payload.value = annotation.lddt
+
         return [payload]
 
     return get_model_structure


### PR DESCRIPTION
In order to color residues by quality (in the structure viewer), the API needs to return a full array of predicted lDDT scores (one per residue). 

The `model:lddt` modifier replaces `model:info` (which returned the entry accession and the average of all lDDT scores).