### PR TITLE
Search by gene

### DIFF
--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -66,7 +66,7 @@ class RESTRequestsTest(FunctionalTest):
 
         num_uniprot = jsonp["proteins"]["uniprot"]
         self.assertEqual(
-            num_uniprot, 4, "the TEST dataset only includes 4 uniprot entries"
+            num_uniprot, 5, "the TEST dataset only includes 5 uniprot entries"
         )
 
         self.browser.get(self.server_url + "/api/protein/uniprot?format=json")

--- a/interpro/settings.py
+++ b/interpro/settings.py
@@ -86,6 +86,7 @@ if INTERPRO_CONFIG.get("django_cors", False):
     MIDDLEWARE = ("corsheaders.middleware.CorsMiddleware",) + MIDDLEWARE
     CORS_ORIGIN_ALLOW_ALL = True
     CORS_ALLOW_CREDENTIALS = False
+    CORS_EXPOSE_HEADERS = ["InterPro-Version"]
 
 ROOT_URLCONF = "interpro.urls"
 

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -346,7 +346,7 @@ class ProteinSerializer(ModelContentSerializer):
             "source_database": obj["protein_db"],
             "organism": obj["tax_id"],
         }
-        if not for_entry:
+        if not for_entry and "structure_chain_acc" in obj:
             header["chain"] = obj["structure_chain_acc"]
         if include_coordinates:
             key_coord = (

--- a/webfront/tests/fixtures_organisms.json
+++ b/webfront/tests/fixtures_organisms.json
@@ -148,6 +148,27 @@
     }
   },
   {
+    "model": "webfront.Taxonomy",
+    "fields": {
+      "accession": "10090",
+      "scientific_name": "Mus musculus",
+      "full_name": "Mus musculus",
+      "lineage": " 1 2579 10090 ",
+      "parent": "2579",
+      "rank": "SPECIES",
+      "children": [],
+      "counts": {
+        "entries": {
+          "total": 0
+        },
+        "structures": 0,
+        "proteins": 1,
+        "sets": 0,
+        "proteomes": 1
+      }
+    }
+  },
+  {
     "model": "webfront.Proteome",
     "fields": {
       "accession": "UP000006701",
@@ -210,6 +231,26 @@
         "proteins": 1,
         "taxa": 1,
         "sets": 1
+      }
+    }
+  },
+  {
+    "model": "webfront.Proteome",
+    "fields": {
+      "accession": "UP000000589",
+      "name": "Mus musculus",
+      "is_reference": true,
+      "strain": "C57BL",
+      "assembly": "GCA_000001635.8 from Ensembl",
+      "taxonomy": "10090",
+      "counts": {
+        "entries": {
+          "total": 0
+        },
+        "structures": 0,
+        "proteins": 1,
+        "taxa": 1,
+        "sets": 0
       }
     }
   },

--- a/webfront/tests/fixtures_protein.json
+++ b/webfront/tests/fixtures_protein.json
@@ -236,6 +236,7 @@
       "accession": "Q0VDM6",
       "tax_id": "10090",
       "organism": {
+        "name": "Mus musculus",
         "scientificName": "Mus musculus",
         "taxId": "10090"
       },

--- a/webfront/tests/fixtures_protein.json
+++ b/webfront/tests/fixtures_protein.json
@@ -230,6 +230,36 @@
     }
   },
   {
+    "model": "webfront.Protein",
+    "fields": {
+      "identifier": "Q0VDM6_MOUSE",
+      "accession": "Q0VDM6",
+      "tax_id": "10090",
+      "organism": {
+        "scientificName": "Mus musculus",
+        "taxId": "10090"
+      },
+      "name": "Folh1 protein",
+      "description": null,
+      "sequence_bin": "H4sIAE1d/F8C/xWRUQ4EIQhDz0ZUHEKHoBA33v8iy/ihhoD2te/eO0DYQO213B2+EpjkzYe3aNv7rI7m0zdNxEYgL1z0iMci3hM2zlEZEit6YNSVjLgbYIghkGWphnNl+CROg2/oRUiznLIV3k+qcMRgY8GQVtOPZB7/nlrzNRshCcWdNnkMWfEQ28yE1J/QYfRA9X2sf6JoTw9Bl4hULILHnag3Ck8oI25Ud1X30E8ROmWBeTyt1XxJTB3LODiEtU5dbUTS3l5SEjdImEYMRP/12+/kFq6J1aicKw3mbXR55+2MfSA/iAmoKnbygA+Q8VxFQW7G28osps7tnbgVhlCcTit1rnvtIem/lQXf4tBkzsP0/X5u6T5lzdi/JyUvyUJfWqnuGnJ5MecPHB/3C8eZp+hfPWU//O1nlIexKh1kZQU7h1hEGrUrKpfpLPOBl9K0V0xULlMBcXbO9pJLMJMEEfQ4JE9aaOEV5PVj0cicUcI4tbzdnbn4QmO2ps+igbu3dg66TSvdnGFaycSXd36Wrht53q7Zrvb2B5BjI824AgAA",
+      "length": 696,
+      "proteome": "UP000000589",
+      "gene": "FOLH1",
+      "go_terms": null,
+      "evidence_code": 1,
+      "source_database": "unreviewed",
+      "is_fragment": false,
+      "counts": {
+        "entries": {
+          "total": 0
+        },
+        "structures": 0,
+        "sets": 0
+      }
+
+    }
+  },
+  {
     "model": "webfront.Isoforms",
     "fields": {
       "accession": "A1CUJ5-2",

--- a/webfront/tests/fixtures_reader.py
+++ b/webfront/tests/fixtures_reader.py
@@ -102,6 +102,8 @@ class FixtureReader:
     def get_fixtures(self):
         to_add = []
         entry2set = self.get_entry2set()
+
+        # Creating obj to add for proteins with entries
         for ep in self.entry_protein_list:
             e = ep["entry"]
             p = ep["protein"]
@@ -113,17 +115,17 @@ class FixtureReader:
                 "entry_integrated": self.entries[e]["integrated"],
                 "entry_date": self.entries[e]["entry_date"],
                 "text_entry": e
-                + " "
-                + self.entries[e]["type"]
-                + " "
-                + (" ".join(self.entries[e]["description"])),
+                              + " "
+                              + self.entries[e]["type"]
+                              + " "
+                              + (" ".join(self.entries[e]["description"])),
                 "protein_acc": p,
                 "protein_db": self.proteins[p]["source_database"],
                 "text_protein": p
-                + " "
-                + self.proteins[p]["source_database"]
-                + " "
-                + (" ".join(self.proteins[p]["description"])),
+                                + " "
+                                + self.proteins[p]["source_database"]
+                                + " "
+                                + (" ".join(self.proteins[p]["description"])),
                 "ida_id": self.proteins[p]["ida_id"],
                 "ida": self.proteins[p]["ida"],
                 "tax_id": self.proteins[p]["organism"]["taxId"],
@@ -141,10 +143,7 @@ class FixtureReader:
             }
             obj["text_taxonomy"] = obj["tax_id"] + " " + (" ".join(obj["tax_lineage"]))
 
-            # if "ida" in ep:
-            #     obj["ida"] = ep["ida"]
-            #     obj["ida_id"] = ep["ida_id"]
-
+            # In case that protein also has a structure
             if p in self.protein_structure_list:
                 for sp in self.protein_structure_list[p]:
                     c = copy.copy(obj)
@@ -189,6 +188,7 @@ class FixtureReader:
                 else:
                     to_add.append(obj)
 
+        # Creating obj to add for proteins without entries but with structures
         proteins = [p["protein"] for p in self.entry_protein_list]
         for p, chains in self.protein_structure_list.items():
             if p not in proteins:
@@ -237,6 +237,7 @@ class FixtureReader:
                         }
                     )
 
+        # getting representative coordinates for IDA
         for ep in self.entry_protein_list:
             e = ep["entry"]
             p = ep["protein"]
@@ -246,6 +247,37 @@ class FixtureReader:
                         ida["representative"]["domains"].append(
                             {"entry": e, "coordinates": ep["coordinates"]}
                         )
+
+        # Creating obj to add for proteins without entry or structure
+        for p in self.proteins:
+            p_ocurrences = len([t for t in to_add if t['protein_acc']==p ])
+            if p_ocurrences == 0:
+                to_add.append(
+                    {
+                        "text": p,
+                        "protein_acc": p,
+                        "protein_db": self.proteins[p]["source_database"],
+                        "text_protein": p
+                                        + " "
+                                        + self.proteins[p]["source_database"],
+                        "tax_id": self.proteins[p]["organism"]["taxId"],
+                        "tax_name": self.proteins[p]["organism"]["name"],
+                        "tax_rank": self.tax2rank[
+                            self.proteins[p]["organism"]["taxId"]
+                        ],
+                        "tax_lineage": self.tax2lineage[
+                            self.proteins[p]["organism"]["taxId"]
+                        ],
+                        "proteome_acc": self.proteomes[proteome]["accession"],
+                        "proteome_name": self.proteomes[proteome]["name"],
+                        "proteome_is_reference": self.proteomes[proteome][
+                            "is_reference"
+                        ],
+                        "protein_length": self.proteins[p]["length"],
+                        "id": get_id(None, p),
+                    }
+                )
+
         lower = []
         for doc in to_add:
             lower.append(

--- a/webfront/tests/tests_3_endpoints_using_searcher.py
+++ b/webfront/tests/tests_3_endpoints_using_searcher.py
@@ -16,13 +16,13 @@ api_test_map = {
         "profile": ["PS50822", "PS01031"],
     },
     "protein": {
-        "uniprot": ["A1CUJ5", "M5ADK6", "A0A0A2L2G2", "P16582"],
+        "uniprot": ["A1CUJ5", "M5ADK6", "A0A0A2L2G2", "P16582", "Q0VDM6"],
         "reviewed": ["A1CUJ5", "M5ADK6"],
-        "unreviewed": ["A0A0A2L2G2", "P16582"],
+        "unreviewed": ["A0A0A2L2G2", "P16582", "Q0VDM6"],
     },
     "structure": {"pdb": ["1JM7", "1T2V", "2BKM", "1JZ8"]},
-    "taxonomy": {"uniprot": ["1", "2", "2579", "40296", "344612", "1001583"]},
-    "proteome": {"uniprot": ["UP000006701", "UP000012042", "UP000030104"]},
+    "taxonomy": {"uniprot": ["1", "2", "2579", "40296", "344612", "1001583", "10090"]},
+    "proteome": {"uniprot": ["UP000006701", "UP000012042", "UP000030104", "UP000000589"]},
     "set": {"pfam": ["CL0001", "CL0002"]},
 }
 

--- a/webfront/tests/tests_modifiers.py
+++ b/webfront/tests/tests_modifiers.py
@@ -24,7 +24,8 @@ class GroupByModifierTest(InterproRESTTestCase):
     def test_can_get_the_entry_type_groups_proteins_by_tax_id(self):
         response = self.client.get("/api/protein?group_by=tax_id")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual({}, response.data)
+        # Only Mus musculus is a key species
+        self.assertEqual({'10090': {'value': 1, 'title': 'Mus musculus'}}, response.data)
 
     def test_can_group_interpro_entries_with_member_databases(self):
         response = self.client.get("/api/entry/interpro?group_by=member_databases")
@@ -45,7 +46,7 @@ class GroupByModifierTest(InterproRESTTestCase):
         self.assertIn("true", response.data["match_presence"])
         self.assertIn("false", response.data["match_presence"])
         self.assertEqual(response.data["match_presence"]["true"], 3)
-        self.assertEqual(response.data["match_presence"]["false"], 1)
+        self.assertEqual(response.data["match_presence"]["false"], 2)
 
     def test_can_get_the_fragment_groups(self):
         response = self.client.get("/api/protein?group_by=is_fragment")

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -7,7 +7,7 @@ from webfront.tests.InterproRESTTestCase import InterproRESTTestCase
 class TaxonomyFixturesTest(InterproRESTTestCase):
     def test_the_fixtures_are_loaded(self):
         taxa = Taxonomy.objects.all()
-        self.assertEqual(taxa.count(), 6)
+        self.assertEqual(taxa.count(), 7)
         names = [t.scientific_name for t in taxa]
         self.assertIn("ROOT", names)
         self.assertNotIn("unicorn", names)
@@ -23,7 +23,7 @@ class TaxonomyFixturesTest(InterproRESTTestCase):
         response = self.client.get("/api/taxonomy/uniprot")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self.assertEqual(len(response.data["results"]), 6)
+        self.assertEqual(len(response.data["results"]), 7)
 
     def test_can_read_taxonomy_id(self):
         response = self.client.get("/api/taxonomy/uniprot/2")
@@ -37,7 +37,7 @@ class TaxonomyProteomeFixturesTest(InterproRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "proteomes")
-        self.assertEqual(len(response.data["results"]), 3)
+        self.assertEqual(len(response.data["results"]), 4)
 
     def test_can_read_taxonomy_leaf_id_with_proteome_count(self):
         response = self.client.get("/api/taxonomy/uniprot/40296/proteome")
@@ -59,7 +59,7 @@ class TaxonomyProteomeFixturesTest(InterproRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("metadata", response.data)
         self.assertIn("proteome_subset", response.data)
-        self.assertEqual(len(response.data["proteome_subset"]), 2)
+        self.assertEqual(len(response.data["proteome_subset"]), 3)
 
     def test_can_read_proteome_id_including_tax_id(self):
         lineage = [1, 2, 40296]

--- a/webfront/tests/tests_protein_endpoint.py
+++ b/webfront/tests/tests_protein_endpoint.py
@@ -12,7 +12,7 @@ class ProteinRESTTest(InterproRESTTestCase):
         response = self.client.get("/api/protein/uniprot")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self.assertEqual(len(response.data["results"]), 4)
+        self.assertEqual(len(response.data["results"]), 5)
 
     def test_can_read_protein_uniprot_accession(self):
         response = self.client.get("/api/protein/uniprot/P16582")

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -7,7 +7,7 @@ from webfront.tests.InterproRESTTestCase import InterproRESTTestCase
 class ProteomeFixturesTest(InterproRESTTestCase):
     def test_the_fixtures_are_loaded(self):
         proteomes = Proteome.objects.all()
-        self.assertEqual(proteomes.count(), 3)
+        self.assertEqual(proteomes.count(), 4)
         names = [t.name for t in proteomes]
         self.assertIn("Lactobacillus brevis KB290", names)
         self.assertNotIn("unicorn", names)
@@ -22,7 +22,7 @@ class ProteomeFixturesTest(InterproRESTTestCase):
         response = self.client.get("/api/proteome/uniprot")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self.assertEqual(len(response.data["results"]), 3)
+        self.assertEqual(len(response.data["results"]), 4)
 
     def test_can_read_proteome_id(self):
         response = self.client.get("/api/proteome/uniprot/UP000012042")

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -19,9 +19,9 @@ api_test_map = {
         "unintegrated/profile": ["PS01031"],
     },
     "protein": {
-        "uniprot": ["A1CUJ5", "M5ADK6", "A0A0A2L2G2", "P16582"],
+        "uniprot": ["A1CUJ5", "M5ADK6", "A0A0A2L2G2", "P16582", "Q0VDM6"],
         "reviewed": ["A1CUJ5", "M5ADK6"],
-        "unreviewed": ["A0A0A2L2G2", "P16582"],
+        "unreviewed": ["A0A0A2L2G2", "P16582", "Q0VDM6"],
     },
     "structure": {"pdb": ["1JM7", "1T2V", "2BKM", "1JZ8"]},
     "taxonomy": {"uniprot": ["1", "2", "2579", "40296", "344612", "1001583"]},

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -24,8 +24,8 @@ api_test_map = {
         "unreviewed": ["A0A0A2L2G2", "P16582", "Q0VDM6"],
     },
     "structure": {"pdb": ["1JM7", "1T2V", "2BKM", "1JZ8"]},
-    "taxonomy": {"uniprot": ["1", "2", "2579", "40296", "344612", "1001583"]},
-    "proteome": {"uniprot": ["UP000006701", "UP000012042", "UP000030104"]},
+    "taxonomy": {"uniprot": ["1", "2", "2579", "40296", "344612", "1001583", "10090"]},
+    "proteome": {"uniprot": ["UP000006701", "UP000012042", "UP000030104", "UP000000589"]},
 }
 plurals = ModelContentSerializer.plurals
 
@@ -252,7 +252,7 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
 
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.assertEqual(
-                                response.status_code, status.HTTP_204_NO_CONTENT
+                                response.status_code, status.HTTP_204_NO_CONTENT, "URL : [{}]".format(current),
                             )
 
     def test_db_acc(self):

--- a/webfront/tests/tests_utils_endpoint.py
+++ b/webfront/tests/tests_utils_endpoint.py
@@ -62,6 +62,15 @@ class UtilsAccessionTest(InterproRESTTestCase):
         self.assertEqual(response.data["source_database"], "reviewed")
         self.assertEqual(response.data["accession"], "A1CUJ5")
 
+    def test_accession_endpoint_with_gene_name(self):
+        response = self.client.get("/api/utils/accession/FOLH1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["endpoint"], "protein")
+        self.assertEqual(response.data["source_database"], "unreviewed")
+        self.assertIn("proteins", response.data)
+        self.assertGreater( len(response.data["proteins"]), 0)
+        self.assertEqual(response.data["proteins"][0]['accession'], "Q0VDM6")
+
 
 class UtilsReleaseTest(InterproRESTTestCase):
     def test_can_read_structure_overview(self):

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -20,11 +20,9 @@ from webfront.views.custom import filter_queryset_accession_in
 from webfront.exceptions import EmptyQuerysetError, HmmerWebError, ExpectedUniqueError, InvalidOperationRequest
 from django.conf import settings
 
-from requests import Session
 from urllib import request, parse
 from json import loads
 import gzip
-# import ssl
 
 # MAQ bypassing SSL errors
 # ssl._create_default_https_context = ssl._create_unverified_context

--- a/webfront/views/utils.py
+++ b/webfront/views/utils.py
@@ -128,7 +128,7 @@ class AccessionHandler(CustomView):
                             {"accession": item.accession,
                              "organism": item.organism["scientificName"],
                              "tax_id":item.tax_id
-                             } for item in qs2[:20]],
+                             } for item in qs2],
                     }
         else:
             hit = docs["hits"]["hits"][0]["_source"]


### PR DESCRIPTION
Extended the `/utils/accession/[term]` to support the search for gene id.
Given that a gene Id can be associated with multiple proteins, and can be in the order of thousands, we limit this response to the proteins in the key species. The payload for this endpoint was also extended. 
For example, a query like `/api/utils/accession/cyc` should return something like:

```json
{
    "endpoint": "protein",
    "source_database": "reviewed",
    "proteins": [
        {
            "accession": "O61734",
            "organism": "Drosophila melanogaster",
            "tax_id": "7227"
        },
        {
            "accession": "Q6IQM2",
            "organism": "Danio rerio",
            "tax_id": "7955"
        }
    ]
}
```
Some extra fixtures were added to test this functionality: 1 protein, associated with 1 proteome and 1 taxon. The fixture loader needed to be updated to include proteins that were neither associated with an entry nor a structure.
