### PR TITLE
Use default IDA index when running tests

### DIFF
--- a/interpro/settings.py
+++ b/interpro/settings.py
@@ -141,6 +141,7 @@ SEARCHER_IDA_INDEX = INTERPRO_CONFIG.get("searcher_ida_index", "ida")
 if INTERPRO_CONFIG.get("use_test_db", True):
     SEARCHER_URL = SEARCHER_TEST_URL
     SEARCHER_INDEX = "test"
+    SEARCHER_IDA_INDEX = "ida"
 TEST_RUNNER = "webfront.tests.managed_model_test_runner.UnManagedModelTestRunner"
 
 # Internationalization


### PR DESCRIPTION
Force the IDA index to be equal to `ida` when testing, overwriting any value of `searcher_ida_index` that could defined in `interpro.local.yml`.