### PR TITLE
extending subfamilies modifier to get a single subfamily

### DIFF
--- a/webfront/static/interpro7-swagger.yml
+++ b/webfront/static/interpro7-swagger.yml
@@ -88,6 +88,8 @@ paths:
         - $ref: "#/components/parameters/entryAnnotationMemberDB"
         - $ref: "#/components/parameters/entryExtraFields"
         - $ref: "#/components/parameters/entryAFmodel"
+        - $ref: "#/components/parameters/entrySubfamilies"
+        - $ref: "#/components/parameters/entrySubfamily"
         #- $ref: "#/components/parameters/entryModelMemberDB" needs to change from ':' to '='
       responses:
         $ref: "#/components/responses/MetadataAndErrors"
@@ -666,6 +668,33 @@ components:
 
       schema:
         type: boolean
+    entrySubfamilies:
+      name: subfamilies
+      in: query
+      description: |
+        Panther families have subfamilies associated with each match. This modifier lists the subfamilies 
+        linked to the current entry.
+        If the attribute has a value (e.g. `subfamilies=PTHR10015:SF361`) the list will be filtered by that ID.
+
+        **Note:** This parameter only works when the sourceDB selected is panther.
+
+         **Note: ** This modifier doesn't operates in combination with other parameters.
+
+      schema:
+        type: string
+    entrySubfamily:
+      name: subfamily
+      in: query
+      description: |
+        Panther families have subfamilies associated with each match. This modifier indicates that the given 
+        accession belongs to a subfamily intead of an entry. For example `/entry/panther/PTHR10015:SF361?subfamily`
+        
+        **Note:** This parameter only works when the sourceDB selected is panther.
+
+         **Note: ** This modifier doesn't operates in combination with other parameters.
+
+      schema:
+        type: string
     entryModelMemberDB:
       name: model
       in: query

--- a/webfront/views/entry.py
+++ b/webfront/views/entry.py
@@ -20,6 +20,7 @@ from webfront.views.modifiers import (
     get_model,
     get_sunburst_taxa,
     get_subfamilies,
+mark_as_subfamily,
 )
 from .custom import CustomView, SerializerDetail
 from django.conf import settings
@@ -98,6 +99,10 @@ class MemberAccessionHandler(CustomView):
             type=ModifierType.REPLACE_PAYLOAD,
             serializer=SerializerDetail.ENTRY_HEADERS,
             many=True,
+        )
+        general_handler.modifiers.register(
+            "subfamily",
+            mark_as_subfamily,
         )
 
         return super(MemberAccessionHandler, self).get(

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -898,10 +898,16 @@ def get_model(field):
 def get_subfamilies(value, general_handler):
     queryset = general_handler.queryset_manager.get_queryset().first()
     entries = Entry.objects.filter(integrated=queryset.accession, is_alive=False)
+    if value is not None and value.strip() != '':
+        entries = entries.filter(accession=value)
     if len(entries) == 0:
         raise EmptyQuerysetError("There is are not subfamilies for this entry")
     general_handler.modifiers.search_size = len(entries)
     return entries
+
+
+def mark_as_subfamily(value, general_handler):
+    general_handler.queryset_manager.add_filter("entry", is_alive=False)
 
 
 def passing(x, y):


### PR DESCRIPTION
Add 2 methods to retrieve data for a particular subfamily:
1. Extending the `subfamilies` attribute. If the attribute has a value,  this will be used as the subfamily accession to filter the list. therefore the result list will only contain a single subfamily, or none if the accession is not found. 
Example: `/entry/panther/PTHR10015/?subfamilies=PTHR10015:SF140`
2. Using the subfamily accession as part of the main URL, but tagging the request with the modifier `subfamily`. 
Example: `/entry/panther/PTHR10015:SF140?subfamily`