### PR TITLE
extending sorting to multiple fields 

### DIFF
--- a/webfront/searcher/elastic_controller.py
+++ b/webfront/searcher/elastic_controller.py
@@ -343,6 +343,8 @@ class ElasticsearchController(SearchController):
             for x in response["aggregations"]["groups"]["buckets"]
         ]
         if reset_direction:
+            if len(facet["aggs"]["groups"]["composite"]["sources"]) > 2:
+                accessions.reverse()
             self.reverseOrderDirection(facet["aggs"]["groups"]["composite"])
         after_key = self.getAfterKey(response, facet, before, qs)
         before_key = self.getBeforeKey(response, facet, before, qs)

--- a/webfront/searcher/elastic_controller.py
+++ b/webfront/searcher/elastic_controller.py
@@ -343,8 +343,7 @@ class ElasticsearchController(SearchController):
             for x in response["aggregations"]["groups"]["buckets"]
         ]
         if reset_direction:
-            if len(facet["aggs"]["groups"]["composite"]["sources"]) > 2:
-                accessions.reverse()
+            accessions.reverse()
             self.reverseOrderDirection(facet["aggs"]["groups"]["composite"])
         after_key = self.getAfterKey(response, facet, before, qs)
         before_key = self.getBeforeKey(response, facet, before, qs)

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -281,17 +281,21 @@ def filter_by_entry_db(value, general_handler):
     return response.first()
 
 
-def filter_by_min_value(endpoint, field, value, sort_direction="asc"):
+def filter_by_min_value(endpoint, field, value, sorting_by=[]):
     def x(_, general_handler):
         general_handler.queryset_manager.add_filter(
             endpoint, **{"{}__gte".format(field): value}
         )
-        if sort_direction in ("asc", "desc"):
-            general_handler.queryset_manager.order_by(
-                "{}:{}".format(field, sort_direction)
-            )
-        else:
-            raise ValueError("{} is not a valid sorting order".format(sort_direction))
+        sort_str = ""
+        connector = ""
+        for sort_field in sorting_by:
+            if sort_field["direction"] in ("asc", "desc"):
+                sort_str += "{}{}:{}".format(connector, sort_field["name"], sort_field["direction"])
+            else:
+                raise ValueError("{} is not a valid sorting order".format(sort_field["direction"]))
+            connector = ","
+        if len(sort_str)>0:
+            general_handler.queryset_manager.order_by(sort_str)
 
     return x
 

--- a/webfront/views/protein.py
+++ b/webfront/views/protein.py
@@ -282,7 +282,10 @@ class ProteinHandler(CustomView):
             "is_fragment", filter_by_boolean_field("protein", "is_fragment")
         )
         general_handler.modifiers.register(
-            "has_model", filter_by_min_value("protein", "protein_af_score", 0, "desc")
+            "has_model", filter_by_min_value("protein", "protein_af_score", 0, sorting_by=[
+                {"name": "protein_is_fragment", "direction": "asc"},
+                {"name": "protein_af_score", "direction": "desc"},
+            ])
         )
 
         return super(ProteinHandler, self).get(


### PR DESCRIPTION
So this is to be able to order the list of alpfafold models linked to an entry by `is_fragment` and `alphafold_score`.

I think there is an issue with the `next` and `back` links, but I guess we can correct that later after the release