### PR TITLE
No cache modifiers

### DIFF
--- a/webfront/tests/tests_utils.py
+++ b/webfront/tests/tests_utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from views.common import map_url_to_levels
+from webfront.views.common import map_url_to_levels
 from webfront.views.cache import canonical, get_timeout_from_path, SHOULD_NO_CACHE, FIVE_DAYS
 
 

--- a/webfront/views/cache.py
+++ b/webfront/views/cache.py
@@ -18,6 +18,27 @@ SHOULD_NO_CACHE = -1
 
 names = [ep["name"].lower() for ep in endpoints]
 
+short_life_parameters = [
+    "cursor",
+    "size",
+    "go_terms",
+    "ida_ignore",
+    "ida_search",
+    "format",
+    "page_size",
+]
+
+no_cache_modifiers = [
+    "extra_features",
+    "residues",
+    "isoforms",
+    "ida",
+    "taxa",
+    "model:"
+    "annotation:info",
+    "subfamilies",
+    "page_size",
+]
 
 def get_timeout_from_path(path, endpoint_levels):
     parsed = urlparse(path)
@@ -31,11 +52,9 @@ def get_timeout_from_path(path, endpoint_levels):
         # it doesn't have modifiers
         if len(query.keys()) == 0:
             return SHOULD_NO_CACHE
-        if (  # The only modifier is page_size
-            len(query.keys()) == 1
-            and "page_size" in query
-        ):
-            return SHOULD_NO_CACHE
+        for parameter in no_cache_modifiers:
+            if parameter in query:
+                return SHOULD_NO_CACHE
 
     # order querystring, lowercase keys
     query = OrderedDict(
@@ -49,14 +68,6 @@ def get_timeout_from_path(path, endpoint_levels):
                 return FIVE_DAYS
         except Exception:
             return SHOULD_NO_CACHE
-    short_life_parameters = [
-        "cursor",
-        "size",
-        "go_terms",
-        "ida_ignore",
-        "ida_search",
-        "format",
-    ]
     for parameter in short_life_parameters:
         value = query.get(parameter)
         if value is not None:

--- a/webfront/views/cache.py
+++ b/webfront/views/cache.py
@@ -26,6 +26,7 @@ short_life_parameters = [
     "ida_search",
     "format",
     "page_size",
+    "search",
 ]
 
 no_cache_modifiers = [
@@ -37,6 +38,7 @@ no_cache_modifiers = [
     "model:"
     "annotation:info",
     "subfamilies",
+    "subfamily",
     "page_size",
 ]
 

--- a/webfront/views/cache.py
+++ b/webfront/views/cache.py
@@ -71,8 +71,7 @@ def get_timeout_from_path(path, endpoint_levels):
         except Exception:
             return SHOULD_NO_CACHE
     for parameter in short_life_parameters:
-        value = query.get(parameter)
-        if value is not None:
+        if parameter in query:
             return FIVE_DAYS
     return None
 

--- a/webfront/views/common.py
+++ b/webfront/views/common.py
@@ -20,7 +20,7 @@ from webfront.views.taxonomy import TaxonomyHandler
 from webfront.views.proteome import ProteomeHandler
 from webfront.views.set import SetHandler
 from webfront.views.utils import UtilsHandler
-from webfront.views.cache import InterProCache, get_timeout_from_path, SHOULD_NO_CACHE
+from webfront.views.cache import InterProCache, get_timeout_from_path, canonical, SHOULD_NO_CACHE
 
 from webfront.models import Database
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
@@ -191,7 +191,7 @@ class GeneralHandler(CustomView):
                     drf_request=drf_request,
                 )
                 # Got a good response, then save it in cache
-                timeout = get_timeout_from_path(full_path, endpoint_levels)
+                timeout = get_timeout_from_path(canonical(full_path), endpoint_levels)
                 if timeout != SHOULD_NO_CACHE:
                     self._set_in_cache(caching_allowed, full_path, response, timeout)
                 # Forcing to close the connection because django is not closing it when this query is ran as future


### PR DESCRIPTION
Adding a list of modifiers that will tag an URL as not cacheable.

For example `/protein/uniprot/p99999/?extra_features` shouldn't be cached because the `extra_features` is a modifier that access the data in mysql via a primary key and therefore is fast enough to not require cache. But `/protein/uniprot/p99999/?conservation` should be cached because `conservation` is a modifier that executes a calculation making it worth to be cached.

Also adding few tests to check some example URLs.