### PR TITLE
fix has_model

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # remember to check the version is compatible with python 3.6
-selenium~=3.141
+selenium==4.9.0
 django-debug-toolbar~=3.2
 ipdb==0.13.9
 coveralls==3.3.1

--- a/webfront/searcher/elastic_controller.py
+++ b/webfront/searcher/elastic_controller.py
@@ -268,7 +268,8 @@ class ElasticsearchController(SearchController):
                 self.add_subterm_aggs(obj, f, rows)
                 obj = obj["aggs"]["subgroups"]
         if fq is not None:
-            query += " && " + fq
+            # the query might have a sorting parameter, so fq needs to be prepend
+            query = fq + " && " + query
         response = self._elastic_json_query(query, facet)
         buckets = response["aggregations"]["groups"]["buckets"]
         if len(buckets) > 0 and "tops" not in buckets[0]:
@@ -412,7 +413,7 @@ class ElasticsearchController(SearchController):
             query = self.queryset_manager.get_searcher_query()
         q = query
         if fq is not None:
-            q = query + " && " + fq.lower()
+            q = fq.lower() + " && " + query
         q = (
             q.replace(" && ", "%20AND%20")
             .replace(" || ", "%20OR%20")


### PR DESCRIPTION
The queries with `has_model=true` had an issue reported in #106 which has been fixed in this PR.

The problem was that the changes in the elastic query were concatenated after the `sort` options were included. Quick fix was to prepend to the query and in that way the added URL argument don't interfered.

Also some dependencies updates.