### PR TITLE
Granular counters

### DIFF
--- a/webfront/models/interpro_new.py
+++ b/webfront/models/interpro_new.py
@@ -186,6 +186,11 @@ class TaxonomyPerEntry(models.Model):
     )
     counts = JSONField(null=True)
 
+    class Meta:
+        indexes = [
+            models.Index(fields=["entry_acc", "taxonomy"]),
+        ]
+
 
 class TaxonomyPerEntryDB(models.Model):
     taxonomy = models.ForeignKey(
@@ -193,6 +198,11 @@ class TaxonomyPerEntryDB(models.Model):
     )
     source_database = models.CharField(max_length=100, db_index=True)
     counts = JSONField(null=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["source_database", "taxonomy"]),
+        ]
 
 
 class Proteome(models.Model):

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -18,9 +18,9 @@ class SetSerializer(ModelContentSerializer):
         )
         if self.queryset_manager.other_fields is not None:
 
-            def counter_function():
+            def counter_function(counters_to_include):
                 return SetSerializer.get_counters(
-                    instance, self.searcher, self.queryset_manager
+                    instance, self.searcher, self.queryset_manager, counters_to_include
                 )
 
             representation = self.add_other_fields(
@@ -88,7 +88,10 @@ class SetSerializer(ModelContentSerializer):
                     else "structure_subset"
                 )
                 representation[key] = self.to_structures_detail_representation(
-                    instance, s, q, include_chain=True,
+                    instance,
+                    s,
+                    q,
+                    include_chain=True,
                     queryset_manager=self.queryset_manager,
                 )
             if (
@@ -167,7 +170,9 @@ class SetSerializer(ModelContentSerializer):
             counters = instance.counts
             self.reformatEntryCounters(counters)
         else:
-            counters = SetSerializer.get_counters(instance, searcher, self.queryset_manager)
+            counters = SetSerializer.get_counters(
+                instance, searcher, self.queryset_manager
+            )
         obj = {
             "metadata": {
                 "accession": instance.accession,
@@ -183,7 +188,7 @@ class SetSerializer(ModelContentSerializer):
         return obj
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "structure": ["structures", "structure_acc"],
@@ -192,11 +197,7 @@ class SetSerializer(ModelContentSerializer):
             "proteome": ["proteomes", "proteome_acc"],
         }
         return ModelContentSerializer.generic_get_counters(
-            "set",
-            endpoints,
-            instance,
-            searcher,
-            queryset_manager
+            "set", endpoints, instance, searcher, queryset_manager, counters_to_include
         )
 
     @staticmethod

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -188,7 +188,7 @@ class SetSerializer(ModelContentSerializer):
         return obj
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager, counters_to_include):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include=None):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "structure": ["structures", "structure_acc"],

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -330,4 +330,6 @@ class ModelContentSerializer(serializers.ModelSerializer):
                 counters[name] = searcher.get_number_of_field_by_endpoint(
                     main_endpoint, field, instance.accession, sq
                 )
+            else:
+                counters[name] = 1
         return counters

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -277,7 +277,7 @@ class ModelContentSerializer(serializers.ModelSerializer):
         }
         for f in functions:
             if f in other_fields:
-                representation["extra_fields"][f] = functions[f]()
+                representation["extra_fields"][f] = functions[f](other_fields[f])
         return representation
 
     @staticmethod
@@ -304,16 +304,32 @@ class ModelContentSerializer(serializers.ModelSerializer):
         return {"next": next_page, "previous": previous, **payload}
 
     @staticmethod
-    def generic_get_counters(main_endpoint, counter_endpoints, instance, searcher, queryset_manager):
+    def generic_get_counters(
+        main_endpoint,
+        counter_endpoints,
+        instance,
+        searcher,
+        queryset_manager,
+        counters_to_include=None,
+    ):
         sq = queryset_manager.get_searcher_query()
+        if counters_to_include is not None:
+            split_counters_to_include = counters_to_include.split("-")
+            counter_endpoints = {
+                k: v
+                for k, v in counter_endpoints.items()
+                if k in split_counters_to_include
+            }
+
         counters = {}
         for ep in counter_endpoints:
-            if (
-                ep not in queryset_manager.filters or(
+            if ep not in queryset_manager.filters or (
                 "accession" not in queryset_manager.filters[ep]
-                and "accession__iexact" not in queryset_manager.filters[ep])
+                and "accession__iexact" not in queryset_manager.filters[ep]
             ):
-                counters[counter_endpoints[ep][0]] = searcher.get_number_of_field_by_endpoint(
-                    main_endpoint, counter_endpoints[ep][1], instance.accession, sq
+                counters[counter_endpoints[ep][0]] = (
+                    searcher.get_number_of_field_by_endpoint(
+                        main_endpoint, counter_endpoints[ep][1], instance.accession, sq
+                    )
                 )
         return counters

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -157,7 +157,7 @@ class ModelContentSerializer(serializers.ModelSerializer):
         instance,
         searcher,
         query,
-        include_structure=True,
+        include_structure=False,
         include_matches=False,
         include_chain=True,
         queryset_manager=None,

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -23,9 +23,9 @@ class EntrySerializer(ModelContentSerializer):
         )
         if self.queryset_manager.other_fields is not None:
 
-            def counter_function():
+            def counter_function(counters_to_include):
                 return EntrySerializer.get_counters(
-                    instance, self.searcher, self.queryset_manager
+                    instance, self.searcher, self.queryset_manager, counters_to_include
                 )
 
             representation = self.add_other_fields(
@@ -247,7 +247,7 @@ class EntrySerializer(ModelContentSerializer):
         return obj
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include):
         endpoints = {
             "protein": ["proteins", "protein_acc"],
             "structure": ["structures", "structure_acc"],
@@ -261,7 +261,8 @@ class EntrySerializer(ModelContentSerializer):
             endpoints,
             instance,
             searcher,
-            queryset_manager
+            queryset_manager,
+            counters_to_include,
         )
 
     def to_headers_representation(self, instance):

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -247,7 +247,7 @@ class EntrySerializer(ModelContentSerializer):
         return obj
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager, counters_to_include):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include=None):
         endpoints = {
             "protein": ["proteins", "protein_acc"],
             "structure": ["structures", "structure_acc"],

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -194,7 +194,7 @@ class StructureSerializer(ModelContentSerializer):
         }
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager, counters_to_include):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include=None):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "protein": ["proteins", "protein_acc"],

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -14,9 +14,9 @@ class StructureSerializer(ModelContentSerializer):
         representation = self.filter_representation(representation, instance)
         if self.queryset_manager.other_fields is not None:
 
-            def counter_function():
+            def counter_function(counters_to_include):
                 return StructureSerializer.get_counters(
-                    instance, self.searcher, self.queryset_manager
+                    instance, self.searcher, self.queryset_manager, counters_to_include
                 )
 
             representation = self.add_other_fields(
@@ -194,7 +194,7 @@ class StructureSerializer(ModelContentSerializer):
         }
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "protein": ["proteins", "protein_acc"],
@@ -207,9 +207,9 @@ class StructureSerializer(ModelContentSerializer):
             endpoints,
             instance,
             searcher,
-            queryset_manager
+            queryset_manager,
+            counters_to_include,
         )
-
 
     @staticmethod
     def get_search_query_from_representation(representation):

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -13,10 +13,10 @@ class ProteomeSerializer(ModelContentSerializer):
         )
         if self.queryset_manager.other_fields is not None:
 
-            def counter_function():
+            def counter_function(counters_to_include):
                 get_c = ProteomeSerializer.get_counters
                 return get_c(
-                    instance, self.searcher, self.queryset_manager
+                    instance, self.searcher, self.queryset_manager, counters_to_include
                 )
 
             representation = self.add_other_fields(
@@ -102,7 +102,10 @@ class ProteomeSerializer(ModelContentSerializer):
                     else "protein_subset"
                 )
                 representation[key] = self.to_proteins_detail_representation(
-                    instance, self.searcher, query_searcher, queryset_manager=self.queryset_manager
+                    instance,
+                    self.searcher,
+                    query_searcher,
+                    queryset_manager=self.queryset_manager,
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters
@@ -137,7 +140,9 @@ class ProteomeSerializer(ModelContentSerializer):
         if self.queryset_manager.is_single_endpoint():
             self.reformatEntryCounters(counters)
         else:
-            counters = ProteomeSerializer.get_counters(instance, searcher, self.queryset_manager)
+            counters = ProteomeSerializer.get_counters(
+                instance, searcher, self.queryset_manager
+            )
         return {
             "metadata": {
                 "accession": instance.accession,
@@ -178,7 +183,7 @@ class ProteomeSerializer(ModelContentSerializer):
         }
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "structure": ["structures", "structure_acc"],
@@ -191,9 +196,9 @@ class ProteomeSerializer(ModelContentSerializer):
             endpoints,
             instance,
             searcher,
-            queryset_manager
+            queryset_manager,
+            counters_to_include,
         )
-
 
     @staticmethod
     def to_counter_representation(instance):

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -183,7 +183,7 @@ class ProteomeSerializer(ModelContentSerializer):
         }
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager, counters_to_include):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include=None):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "structure": ["structures", "structure_acc"],

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -17,12 +17,10 @@ class TaxonomySerializer(ModelContentSerializer):
         )
         if self.queryset_manager.other_fields is not None:
 
-            def counter_function():
+            def counter_function(counters_to_include):
                 get_c = TaxonomySerializer.get_counters
                 return get_c(
-                    instance,
-                    self.searcher,
-                    self.queryset_manager,
+                    instance, self.searcher, self.queryset_manager, counters_to_include
                 )
 
             representation = self.add_other_fields(
@@ -238,7 +236,7 @@ class TaxonomySerializer(ModelContentSerializer):
         return False
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include):
         if TaxonomySerializer.can_use_taxonomy_per_entry(queryset_manager.filters):
             match = TaxonomyPerEntry.objects.filter(
                 entry_acc=queryset_manager.filters["entry"]["accession"].upper(),
@@ -272,9 +270,9 @@ class TaxonomySerializer(ModelContentSerializer):
             endpoints,
             instance,
             searcher,
-            queryset_manager
+            queryset_manager,
+            counters_to_include,
         )
-
 
     @staticmethod
     def to_counter_representation(instance, filter=None):

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -234,7 +234,7 @@ class TaxonomySerializer(ModelContentSerializer):
         return "source_database" in filters["entry"]
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager, counters_to_include):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include=None):
         if TaxonomySerializer.can_use_taxonomy_per_entry(queryset_manager.filters):
             match = TaxonomyPerEntry.objects.filter(
                 entry_acc=queryset_manager.filters["entry"]["accession"].upper(),

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -200,7 +200,7 @@ class ProteinSerializer(ModelContentSerializer):
         return protein
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager, counters_to_include):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include=None):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "structure": ["structures", "structure_acc"],

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -25,9 +25,9 @@ class ProteinSerializer(ModelContentSerializer):
         )
         if self.queryset_manager.other_fields is not None:
 
-            def counter_function():
+            def counter_function(counters_to_include):
                 return ProteinSerializer.get_counters(
-                    instance, self.searcher, self.queryset_manager
+                    instance, self.searcher, self.queryset_manager, counters_to_include
                 )
 
             representation = self.add_other_fields(
@@ -200,7 +200,7 @@ class ProteinSerializer(ModelContentSerializer):
         return protein
 
     @staticmethod
-    def get_counters(instance, searcher, queryset_manager):
+    def get_counters(instance, searcher, queryset_manager, counters_to_include):
         endpoints = {
             "entry": ["entries", "entry_acc"],
             "structure": ["structures", "structure_acc"],
@@ -213,9 +213,9 @@ class ProteinSerializer(ModelContentSerializer):
             endpoints,
             instance,
             searcher,
-            queryset_manager
+            queryset_manager,
+            counters_to_include,
         )
-
 
     @staticmethod
     def to_group_representation(instance):

--- a/webfront/tests/tests_modifiers.py
+++ b/webfront/tests/tests_modifiers.py
@@ -327,6 +327,77 @@ class ExtraFieldsModifierTest(InterproRESTTestCase):
                 response = self.client.get(url)
                 self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    accession = {
+        "entry": "IPR003165",
+        "protein": "a1cuj5",
+        "structure": "1jm7",
+        "taxonomy": "2579",
+        "proteome": "up000006701",
+        "set": "cl0001",
+    }
+
+    def test_counters_as_extra_fields(self):
+        for endpoint1, path1 in self.list_url.items():
+            for endpoint2, path2 in self.list_url.items():
+                if endpoint1 == endpoint2:
+                    continue
+                url = f"/api{path1}{path2}/{self.accession[endpoint2]}?extra_fields=counters"
+                response = self.client.get(url)
+                if response.status_code == status.HTTP_200_OK:
+                    self.assertIn("results", response.data)
+                    for result in response.data["results"]:
+                        self.assertIn("extra_fields", result)
+                        self.assertIn("counters", result["extra_fields"])
+                        self.assertGreater(
+                            len(result["extra_fields"]["counters"].keys()), 1
+                        )
+                else:
+                    self.assertEqual(
+                        response.status_code,
+                        status.HTTP_204_NO_CONTENT,
+                        f"ERROR CODE [{response.status_code}]: {url}",
+                    )
+
+    def test_granular_counters_as_extra_fields(self):
+        counters_to_ask = [
+            ["entry"],
+            ["protein"],
+            ["entry", "protein"],
+        ]
+        for endpoint1, path1 in self.list_url.items():
+            for endpoint2, path2 in self.list_url.items():
+                for counters in counters_to_ask:
+                    if (
+                        endpoint1 == endpoint2
+                        or endpoint1 in counters
+                        or endpoint2 in counters
+                    ):
+                        continue
+                    url = f"/api{path1}{path2}/{self.accession[endpoint2]}?extra_fields=counters:{'-'.join(counters)}"
+                    response = self.client.get(url)
+                    if response.status_code == status.HTTP_200_OK:
+                        self.assertIn("results", response.data)
+                        for result in response.data["results"]:
+                            self.assertIn("extra_fields", result)
+                            self.assertIn("counters", result["extra_fields"])
+                            if endpoint1 == "taxonomy" and endpoint2 == "entry":
+                                # In this case the counters come from TaxonomyPerEntry and are always 3.
+                                self.assertEqual(
+                                    len(result["extra_fields"]["counters"].keys()), 3
+                                )
+                            else:
+                                # Otherwise it should be equal to the counters requested
+                                self.assertEqual(
+                                    len(result["extra_fields"]["counters"].keys()),
+                                    len(counters),
+                                )
+                    else:
+                        self.assertEqual(
+                            response.status_code,
+                            status.HTTP_204_NO_CONTENT,
+                            f"ERROR CODE [{response.status_code}]: {url}",
+                        )
+
 
 class ExtraFeaturesModifierTest(InterproRESTTestCase):
     def test_extra_features_modifier_is_different_than_acc_protein(self):

--- a/webfront/tests/tests_modifiers.py
+++ b/webfront/tests/tests_modifiers.py
@@ -327,6 +327,9 @@ class ExtraFieldsModifierTest(InterproRESTTestCase):
                 response = self.client.get(url)
                 self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_counters_as_extra_fields(self):
+
+
 
 class ExtraFeaturesModifierTest(InterproRESTTestCase):
     def test_extra_features_modifier_is_different_than_acc_protein(self):

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -260,19 +260,26 @@ def filter_by_key_species(value, general_handler):
 
 def filter_by_entry(value, general_handler):
     queryset = general_handler.queryset_manager.get_queryset()
-    response = TaxonomyPerEntry.objects.filter(taxonomy__in=queryset).filter(
-        entry_acc__accession__iexact=value
-    )
+    response = (TaxonomyPerEntry.objects
+                .filter(taxonomy__in=queryset)
+                .filter(entry_acc__accession=value.upper())
+                )
     if len(response) == 0:
-        raise EmptyQuerysetError("No documents found with the current selection")
+        response = (TaxonomyPerEntry.objects
+                    .filter(taxonomy__in=queryset)
+                    .filter(entry_acc__accession=value.lower())
+                    )
+        if len(response) == 0:
+            raise EmptyQuerysetError("No documents found with the current selection")
     return response.first()
 
 
 def filter_by_entry_db(value, general_handler):
     queryset = general_handler.queryset_manager.get_queryset()
-    response = TaxonomyPerEntryDB.objects.filter(taxonomy__in=queryset).filter(
-        source_database__iexact=value
-    )
+    response = (TaxonomyPerEntryDB.objects
+                .filter(taxonomy__in=queryset)
+                .filter(source_database=value.lower())
+                )
     if len(response) == 0:
         raise EmptyQuerysetError("No documents found with the current selection")
 

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -473,14 +473,18 @@ def add_extra_fields(endpoint, *argv):
 
     def x(fields, general_handler):
         fs = fields.split(",")
+        other_fields = {}
         for field in fs:
-            if field not in supported_fields:
+            parts = field.split(":")
+            f_name = parts[0]
+            other_fields[f_name] = parts[1] if len(parts) > 1 else None
+            if f_name not in supported_fields:
                 raise URLError(
                     "{} is not a valid field to to be included. Allowed fields : {}".format(
                         field, ", ".join(supported_fields)
                     )
                 )
-        general_handler.queryset_manager.other_fields = fs
+        general_handler.queryset_manager.other_fields = other_fields
 
     return x
 

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -259,27 +259,24 @@ def filter_by_key_species(value, general_handler):
 
 
 def filter_by_entry(value, general_handler):
-    queryset = general_handler.queryset_manager.get_queryset()
-    response = (TaxonomyPerEntry.objects
-                .filter(taxonomy__in=queryset)
-                .filter(entry_acc__accession=value.upper())
-                )
+    tax_id = general_handler.queryset_manager.filters["taxonomy"]["accession"]
+    response = TaxonomyPerEntry.objects.filter(taxonomy__accession=tax_id).filter(
+        entry_acc__accession=value.upper()
+    )
     if len(response) == 0:
-        response = (TaxonomyPerEntry.objects
-                    .filter(taxonomy__in=queryset)
-                    .filter(entry_acc__accession=value.lower())
-                    )
+        response = TaxonomyPerEntry.objects.filter(taxonomy__in=tax_id).filter(
+            entry_acc__accession=value.lower()
+        )
         if len(response) == 0:
             raise EmptyQuerysetError("No documents found with the current selection")
     return response.first()
 
 
 def filter_by_entry_db(value, general_handler):
-    queryset = general_handler.queryset_manager.get_queryset()
-    response = (TaxonomyPerEntryDB.objects
-                .filter(taxonomy__in=queryset)
-                .filter(source_database=value.lower())
-                )
+    tax_id = general_handler.queryset_manager.filters["taxonomy"]["accession"]
+    response = TaxonomyPerEntryDB.objects.filter(taxonomy__accession=tax_id).filter(
+        source_database=value.lower()
+    )
     if len(response) == 0:
         raise EmptyQuerysetError("No documents found with the current selection")
 

--- a/webfront/views/taxonomy.py
+++ b/webfront/views/taxonomy.py
@@ -34,7 +34,7 @@ class TaxonomyAccessionHandler(CustomView):
         **kwargs
     ):
         general_handler.queryset_manager.add_filter(
-            "taxonomy", accession__iexact=endpoint_levels[level - 1]
+            "taxonomy", accession=endpoint_levels[level - 1]
         )
         general_handler.modifiers.register(
             "with_names", passing, serializer=SerializerDetail.TAXONOMY_DETAIL_NAMES


### PR DESCRIPTION
This PR adds the capability to specify which counter to be included when using the modifier `extra_fields`.

The way it works is that in requests that require a particular counter to be included, it can be specified on the URL with a `-` separated list. For example:

* `/api/set/pfam/taxonomy/uniprot/9606?extra_fields=counters:protein` will return a list of clans that are linked with the `9606` taxonomy, and will include only the `protein` counter as an extra field
* `/api/protein/uniprot/entry/interpro/ipr000001?extra_fields=counters:set-structure` will return a list of proteins that have a match with IPR000001, and will include the `set` and `structure` counters as an extra field.

If the URL doesn't include the list of counter it will return all the available counters on that endpoint. e.g.
* `/api/entry/interpro/protein/uniprot/p99999?extra_fields=counters`.

Finally in the case of URLs where the first endpoint is `taxonomy` and the second is entry, the response will always return all the counters, as they are coming from the DB tables `TaxPerEntry` and `TaxPerEntryDB` and there won't be. any performance win by cherry pick the counters. for example:

`/api/taxonomy/uniprot/entry/interpro/ipr000001?extra_fields=counters:structure` and `/api/taxonomy/uniprot/entry/interpro/ipr000001?extra_fields=counters` will return the same number of counters