### PR TITLE
Pagination links to current API URL

### DIFF
--- a/webfront/views/common.py
+++ b/webfront/views/common.py
@@ -135,12 +135,9 @@ def replace_link_to_current_api(link):
 
 
 def set_pagination_links_to_current_api(response):
-    if "next" in response.data and response.data["next"] is not None:
-        response.data["next"] = replace_link_to_current_api(response.data["next"])
-    if "previous" in response.data and response.data["previous"] is not None:
-        response.data["previous"] = replace_link_to_current_api(
-            response.data["previous"]
-        )
+    for key in ["next", "previous"]:
+        if key in response.data and response.data[key] is not None:
+            response.data[key] = replace_link_to_current_api(response.data[key])
 
 
 class GeneralHandler(CustomView):


### PR DESCRIPTION
This PR solves an issue better described following this steps:
1. A user navigates in the website to any of the data tables populated by our API. For example: [proteins with IPR000001 matches ](https://www.ebi.ac.uk/interpro/entry/InterPro/IPR000001/protein/UniProt/#table).
   * If the user is the first one to reach this page the API request will be cached in redis
   * This requests includes pagination links that are pointing to `/wwwapi` as this was the URL that received the request.
2. The user proceeds to create a script that paginates the results, and the user uses `/api` to run its script.
3. The first page retrieved comes from the cache and now have pagination links to `/wwwapi`
4. Any subsequent call on this script will be pointing to `/wwwapi` which is and undesirable behavior that might affect the performance of the web for all users.

The PR then make sure to overwrite all pagination links coming from a response retrieved from the cache to point to the originator of the call.

It include tests to check the functions.