### PR TITLE
sort by in sets

### DIFF
--- a/webfront/views/set.py
+++ b/webfront/views/set.py
@@ -5,7 +5,7 @@ from webfront.serializers.collection import SetSerializer
 from webfront.views.custom import CustomView, SerializerDetail
 from django.conf import settings
 
-from webfront.views.modifiers import add_extra_fields, get_deprecated_response
+from webfront.views.modifiers import add_extra_fields, get_deprecated_response, sort_by
 
 entry_sets = "|".join(settings.ENTRY_SETS) + "|all"
 entry_sets_accessions = r"^({})$".format(
@@ -149,6 +149,10 @@ class SetHandler(CustomView):
     ):
         general_handler.queryset_manager.reset_filters("set", endpoint_levels)
         general_handler.queryset_manager.add_filter("set", accession__isnull=False)
+        general_handler.modifiers.register(
+            "sort_by",
+            sort_by({"accession": "set_acc"}),
+        )
 
         return super(SetHandler, self).get(
             request._request,


### PR DESCRIPTION
Sorting sets by accession. is now possible using the `sort_by=accession` or `sort_by=-accession` in sets.

Examples:
* http://localhost:8007/api/set/cdd/?sort_by=accession
* http://localhost:8007/api/set/pfam/?sort_by=-accession