### PR TITLE
Replacing `_subset` with `_url` in filter by DB requests

### DIFF
--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -65,9 +65,11 @@ class SetSerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-
-                key = self.get_entries_key(
-                    detail_filters, self.queryset_manager.show_subset
+                key = self.get_endpoint_key(
+                    "entry",
+                    SerializerDetail.ENTRY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
 
                 representation[key] = self.to_entries_detail_representation(
@@ -98,13 +100,19 @@ class SetSerializer(ModelContentSerializer):
                 SerializerDetail.PROTEIN_DB in detail_filters
                 or SerializerDetail.PROTEIN_DETAIL in detail_filters
             ):
-                key = (
-                    "proteins"
-                    if SerializerDetail.PROTEIN_DETAIL in detail_filters
-                    else "protein_subset"
+                key = self.get_endpoint_key(
+                    "protein",
+                    SerializerDetail.PROTEIN_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteins_detail_representation(
-                    instance, self.searcher, q, queryset_manager=self.queryset_manager
+                    instance,
+                    self.searcher,
+                    q,
+                    key == "proteins_url",
+                    queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -61,22 +61,22 @@ class SetSerializer(ModelContentSerializer):
             )
         if detail != SerializerDetail.SET_OVERVIEW:
             q = "set_acc:" + escape(instance.accession.lower())
-            sq = self.queryset_manager.get_searcher_query()
             if (
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = (
-                    "entries"
-                    if SerializerDetail.ENTRY_DETAIL in detail_filters
-                    else "entry_subset"
+
+                key = self.get_entries_key(
+                    detail_filters, self.queryset_manager.show_subset
                 )
+
                 representation[key] = self.to_entries_detail_representation(
                     instance,
                     s,
                     q,
-                    base_query=sq,
+                    key == "entries_url",
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -76,9 +76,9 @@ class SetSerializer(ModelContentSerializer):
                     instance,
                     s,
                     q,
+                    self.context["request"],
                     key == "entries_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters
@@ -94,10 +94,10 @@ class SetSerializer(ModelContentSerializer):
                     instance,
                     s,
                     q,
+                    self.context["request"],
                     key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters
@@ -113,9 +113,9 @@ class SetSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     q,
+                    self.context["request"],
                     key == "proteins_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters
@@ -132,8 +132,8 @@ class SetSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     q,
+                    self.context["request"],
                     key == "taxa_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters
@@ -149,8 +149,8 @@ class SetSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     q,
+                    self.context["request"],
                     key == "proteomes_url",
-                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -121,13 +121,19 @@ class SetSerializer(ModelContentSerializer):
                 SerializerDetail.TAXONOMY_DB in detail_filters
                 or SerializerDetail.TAXONOMY_DETAIL in detail_filters
             ):
-                key = (
-                    "taxa"
-                    if SerializerDetail.TAXONOMY_DETAIL in detail_filters
-                    else "taxonomy_subset"
+                key = self.get_endpoint_key(
+                    "taxonomy",
+                    SerializerDetail.TAXONOMY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
+
                 representation[key] = self.to_taxonomy_detail_representation(
-                    instance, self.searcher, q
+                    instance,
+                    self.searcher,
+                    q,
+                    key == "taxa_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -130,13 +130,18 @@ class SetSerializer(ModelContentSerializer):
                 SerializerDetail.PROTEOME_DB in detail_filters
                 or SerializerDetail.PROTEOME_DETAIL in detail_filters
             ):
-                key = (
-                    "proteomes"
-                    if SerializerDetail.PROTEOME_DETAIL in detail_filters
-                    else "proteome_subset"
+                key = self.get_endpoint_key(
+                    "proteome",
+                    SerializerDetail.PROTEOME_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteomes_detail_representation(
-                    self.searcher, q
+                    instance,
+                    self.searcher,
+                    q,
+                    key == "proteomes_url",
+                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/collection.py
+++ b/webfront/serializers/collection.py
@@ -84,17 +84,20 @@ class SetSerializer(ModelContentSerializer):
                 SerializerDetail.STRUCTURE_DB in detail_filters
                 or SerializerDetail.STRUCTURE_DETAIL in detail_filters
             ):
-                key = (
-                    "structures"
-                    if SerializerDetail.STRUCTURE_DETAIL in detail_filters
-                    else "structure_subset"
+                key = self.get_endpoint_key(
+                    "structure",
+                    SerializerDetail.STRUCTURE_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_structures_detail_representation(
                     instance,
                     s,
                     q,
+                    key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -136,7 +136,7 @@ class ModelContentSerializer(serializers.ModelSerializer):
         if elastic_docs["hits"]["total"]["value"] == 0:
             raise EmptyQuerysetError("No entries found matching this request")
         return request.build_absolute_uri(
-            re.sub("/$", "", settings.INTERPRO_CONFIG.get("api_url"))
+            settings.INTERPRO_CONFIG.get("api_url").strip("/")
             + reverse_url(request.get_full_path(), endpoint, instance.accession)
         )
 

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -140,14 +140,25 @@ class ModelContentSerializer(serializers.ModelSerializer):
         return response
 
     @staticmethod
-    def to_set_detail_representation(instance, searcher, query, include_chains=False):
+    def to_set_detail_representation(
+        instance,
+        searcher,
+        searcher_query,
+        show_url,
+        include_chains=False,
+        request=None,
+    ):
+        if show_url and request is not None:
+            return ModelContentSerializer.get_url_for_endpoint(
+                instance, "set", searcher, searcher_query, request
+            )
         fields = ["set_acc", "structure_chain"] if include_chains else "set_acc"
         response = [
             webfront.serializers.collection.SetSerializer.get_set_from_search_object(
                 r, include_chains
             )
             for r in searcher.get_group_obj_of_field_by_query(
-                None, fields, fq=query, rows=20
+                None, fields, fq=searcher_query, rows=20
             )["groups"]
         ]
         if len(response) == 0:

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -142,9 +142,14 @@ class ModelContentSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def to_taxonomy_detail_representation(
-        instance, searcher, searcher_query, show_url, include_chains=False, request=None
+        instance,
+        searcher,
+        searcher_query,
+        request,
+        show_url,
+        include_chains=False,
     ):
-        if show_url and request is not None:
+        if show_url:
             return ModelContentSerializer.get_url_for_endpoint(
                 instance, "taxonomy", searcher, searcher_query, request
             )
@@ -168,11 +173,11 @@ class ModelContentSerializer(serializers.ModelSerializer):
         instance,
         searcher,
         searcher_query,
+        request,
         show_url,
         include_chains=False,
-        request=None,
     ):
-        if show_url and request is not None:
+        if show_url:
             return ModelContentSerializer.get_url_for_endpoint(
                 instance, "set", searcher, searcher_query, request
             )
@@ -194,12 +199,12 @@ class ModelContentSerializer(serializers.ModelSerializer):
         instance,
         searcher,
         searcher_query,
+        request,
         show_url,
         include_structure=False,
         include_matches=False,
         include_chain=True,
         queryset_manager=None,
-        request=None,
     ):
         if show_url and request is not None:
             return ModelContentSerializer.get_url_for_endpoint(
@@ -227,13 +232,13 @@ class ModelContentSerializer(serializers.ModelSerializer):
         instance,
         searcher,
         searcher_query,
+        request,
         show_url,
         include_chains=False,
         for_structure=False,
         queryset_manager=None,
-        request=None,
     ):
-        if show_url and request is not None:
+        if show_url:
             return ModelContentSerializer.get_url_for_endpoint(
                 instance, "entry", searcher, searcher_query, request
             )
@@ -272,14 +277,14 @@ class ModelContentSerializer(serializers.ModelSerializer):
         instance,
         searcher,
         searcher_query,
+        request,
         show_url,
         include_chains=False,
         include_coordinates=True,
         for_entry=False,
         queryset_manager=None,
-        request=None,
     ):
-        if show_url and request is not None:
+        if show_url:
             return ModelContentSerializer.get_url_for_endpoint(
                 instance, "protein", searcher, searcher_query, request
             )
@@ -306,11 +311,11 @@ class ModelContentSerializer(serializers.ModelSerializer):
         instance,
         searcher,
         searcher_query,
+        request,
         show_url,
         include_chains=False,
-        request=None,
     ):
-        if show_url and request is not None:
+        if show_url:
             return ModelContentSerializer.get_url_for_endpoint(
                 instance, "proteome", searcher, searcher_query, request
             )
@@ -420,10 +425,10 @@ def process_counters_attribute(granular_counters, counter_endpoints):
     return counter_endpoints
 
 
-def reverse_url(path, new_main_endpoint, accession=None):
+def reverse_url(path, new_main_endpoint, accession):
     parts = path.split("?")
     ep_parts = re.split("(entry|protein|structure|taxonomy|proteome|set)", parts[0])
-    if accession is not None and accession.lower() not in ep_parts[2].lower():
+    if accession.lower() not in ep_parts[2].lower():
         ep_parts[2] += "/" + accession
     ep_index = ep_parts.index(new_main_endpoint)
     new_order = (

--- a/webfront/serializers/content_serializers.py
+++ b/webfront/serializers/content_serializers.py
@@ -281,7 +281,18 @@ class ModelContentSerializer(serializers.ModelSerializer):
         return response
 
     @staticmethod
-    def to_proteomes_detail_representation(searcher, query, include_chains=False):
+    def to_proteomes_detail_representation(
+        instance,
+        searcher,
+        searcher_query,
+        show_url,
+        include_chains=False,
+        request=None,
+    ):
+        if show_url and request is not None:
+            return ModelContentSerializer.get_url_for_endpoint(
+                instance, "proteome", searcher, searcher_query, request
+            )
         fields = (
             ["proteome_acc", "structure_chain"] if include_chains else "proteome_acc"
         )
@@ -290,7 +301,7 @@ class ModelContentSerializer(serializers.ModelSerializer):
                 r, include_chain=include_chains
             )
             for r in searcher.get_group_obj_of_field_by_query(
-                None, fields, fq=query, rows=20
+                None, fields, fq=searcher_query, rows=20
             )["groups"]
         ]
         if len(response) == 0:

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -131,13 +131,18 @@ class EntrySerializer(ModelContentSerializer):
                 SerializerDetail.PROTEOME_DB in detail_filters
                 or SerializerDetail.PROTEOME_DETAIL in detail_filters
             ):
-                key = (
-                    "proteomes"
-                    if SerializerDetail.PROTEOME_DETAIL in detail_filters
-                    else "proteome_subset"
+                key = self.get_endpoint_key(
+                    "proteome",
+                    SerializerDetail.PROTEOME_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteomes_detail_representation(
-                    self.searcher, "entry_acc:" + escape(instance.accession.lower())
+                    instance,
+                    self.searcher,
+                    "entry_acc:" + escape(instance.accession.lower()),
+                    key == "proteomes_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -99,19 +99,22 @@ class EntrySerializer(ModelContentSerializer):
                 SerializerDetail.STRUCTURE_DB in detail_filters
                 or SerializerDetail.STRUCTURE_DETAIL in detail_filters
             ):
-                key = (
-                    "structures"
-                    if SerializerDetail.STRUCTURE_DETAIL in detail_filters
-                    else "structure_subset"
+                key = self.get_endpoint_key(
+                    "structure",
+                    SerializerDetail.STRUCTURE_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_structures_detail_representation(
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    key == "structures_url",
                     include_structure=SerializerDetail.STRUCTURE_DETAIL
                     not in detail_filters,
                     include_matches=True,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -90,10 +90,10 @@ class EntrySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "proteins_url",
                     for_entry=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters
@@ -109,12 +109,12 @@ class EntrySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "structures_url",
                     include_structure=SerializerDetail.STRUCTURE_DETAIL
                     not in detail_filters,
                     include_matches=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters
@@ -130,8 +130,8 @@ class EntrySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "taxa_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters
@@ -147,8 +147,8 @@ class EntrySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "proteomes_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters
@@ -164,8 +164,8 @@ class EntrySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "sets_url",
-                    request=self.context["request"],
                 )
 
         return representation

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -151,15 +151,18 @@ class EntrySerializer(ModelContentSerializer):
                 SerializerDetail.SET_DB in detail_filters
                 or SerializerDetail.SET_DETAIL in detail_filters
             ):
-                key = (
-                    "sets"
-                    if SerializerDetail.SET_DETAIL in detail_filters
-                    else "set_subset"
+                key = self.get_endpoint_key(
+                    "set",
+                    SerializerDetail.SET_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_set_detail_representation(
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    key == "sets_url",
+                    request=self.context["request"],
                 )
 
         return representation

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -120,15 +120,18 @@ class EntrySerializer(ModelContentSerializer):
                 SerializerDetail.TAXONOMY_DB in detail_filters
                 or SerializerDetail.TAXONOMY_DETAIL in detail_filters
             ):
-                key = (
-                    "taxa"
-                    if SerializerDetail.TAXONOMY_DETAIL in detail_filters
-                    else "taxonomy_subset"
+                key = self.get_endpoint_key(
+                    "taxonomy",
+                    SerializerDetail.TAXONOMY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_taxonomy_detail_representation(
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    key == "taxa_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters

--- a/webfront/serializers/interpro.py
+++ b/webfront/serializers/interpro.py
@@ -75,22 +75,25 @@ class EntrySerializer(ModelContentSerializer):
             representation["sets"] = self.to_set_count_representation(instance)
 
         if detail != SerializerDetail.ENTRY_OVERVIEW:
-            sq = self.queryset_manager.get_searcher_query()
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters
                 or SerializerDetail.PROTEIN_DETAIL in detail_filters
             ):
-                key = (
-                    "proteins"
-                    if SerializerDetail.PROTEIN_DETAIL in detail_filters
-                    else "protein_subset"
+                key = self.get_endpoint_key(
+                    "protein",
+                    SerializerDetail.PROTEIN_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
+
                 representation[key] = EntrySerializer.to_proteins_detail_representation(
                     instance,
                     self.searcher,
                     "entry_acc:" + escape(instance.accession.lower()),
+                    key == "proteins_url",
                     for_entry=True,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -140,15 +140,19 @@ class StructureSerializer(ModelContentSerializer):
                 SerializerDetail.PROTEOME_DB in detail_filters
                 or SerializerDetail.PROTEOME_DETAIL in detail_filters
             ):
-                key = (
-                    "proteomes"
-                    if SerializerDetail.PROTEOME_DETAIL in detail_filters
-                    else "proteome_subset"
+                key = self.get_endpoint_key(
+                    "proteome",
+                    SerializerDetail.PROTEOME_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteomes_detail_representation(
+                    instance,
                     self.searcher,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    key == "proteomes_url",
                     include_chains=True,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -158,15 +158,18 @@ class StructureSerializer(ModelContentSerializer):
                 SerializerDetail.SET_DB in detail_filters
                 or SerializerDetail.SET_DETAIL in detail_filters
             ):
-                key = (
-                    "sets"
-                    if SerializerDetail.SET_DETAIL in detail_filters
-                    else "set_subset"
+                key = self.get_endpoint_key(
+                    "set",
+                    SerializerDetail.SET_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_set_detail_representation(
                     instance,
                     self.searcher,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    key == "sets_url",
+                    request=self.context["request"],
                     include_chains=True,
                 )
 

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -79,7 +79,6 @@ class StructureSerializer(ModelContentSerializer):
             representation["sets"] = self.to_set_count_representation(representation)
 
         if self.detail != SerializerDetail.STRUCTURE_OVERVIEW:
-            sq = self.queryset_manager.get_searcher_query()
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters
                 or SerializerDetail.PROTEIN_DETAIL in detail_filters
@@ -95,10 +94,10 @@ class StructureSerializer(ModelContentSerializer):
                         instance,
                         s,
                         "structure_acc:" + escape(instance.accession.lower()),
+                        self.context["request"],
                         key == "proteins_url",
                         include_chains=True,
                         queryset_manager=self.queryset_manager,
-                        request=self.context["request"],
                     )
                 )
             if (
@@ -115,11 +114,11 @@ class StructureSerializer(ModelContentSerializer):
                     instance,
                     s,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "entries_url",
                     include_chains=True,
                     for_structure=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters
@@ -135,9 +134,9 @@ class StructureSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "taxa_url",
                     include_chains=True,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters
@@ -153,9 +152,9 @@ class StructureSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "proteomes_url",
                     include_chains=True,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters
@@ -171,8 +170,8 @@ class StructureSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "sets_url",
-                    request=self.context["request"],
                     include_chains=True,
                 )
 

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -125,16 +125,19 @@ class StructureSerializer(ModelContentSerializer):
                 SerializerDetail.TAXONOMY_DB in detail_filters
                 or SerializerDetail.TAXONOMY_DETAIL in detail_filters
             ):
-                key = (
-                    "taxa"
-                    if SerializerDetail.TAXONOMY_DETAIL in detail_filters
-                    else "taxonomy_subset"
+                key = self.get_endpoint_key(
+                    "taxonomy",
+                    SerializerDetail.TAXONOMY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_taxonomy_detail_representation(
                     instance,
                     self.searcher,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    key == "taxa_url",
                     include_chains=True,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -84,26 +84,32 @@ class StructureSerializer(ModelContentSerializer):
                 SerializerDetail.PROTEIN_DB in detail_filters
                 or SerializerDetail.PROTEIN_DETAIL in detail_filters
             ):
-                key = (
-                    "proteins"
-                    if SerializerDetail.PROTEIN_DETAIL in detail_filters
-                    else "protein_subset"
+                key = self.get_endpoint_key(
+                    "protein",
+                    SerializerDetail.PROTEIN_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = (
                     StructureSerializer.to_proteins_detail_representation(
                         instance,
                         s,
                         "structure_acc:" + escape(instance.accession.lower()),
+                        key == "proteins_url",
                         include_chains=True,
                         queryset_manager=self.queryset_manager,
+                        request=self.context["request"],
                     )
                 )
             if (
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = self.get_entries_key(
-                    detail_filters, self.queryset_manager.show_subset
+                key = self.get_endpoint_key(
+                    "entry",
+                    SerializerDetail.ENTRY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_entries_detail_representation(
                     instance,

--- a/webfront/serializers/pdb.py
+++ b/webfront/serializers/pdb.py
@@ -102,19 +102,18 @@ class StructureSerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = (
-                    "entries"
-                    if SerializerDetail.ENTRY_DETAIL in detail_filters
-                    else "entry_subset"
+                key = self.get_entries_key(
+                    detail_filters, self.queryset_manager.show_subset
                 )
                 representation[key] = self.to_entries_detail_representation(
                     instance,
                     s,
                     "structure_acc:" + escape(instance.accession.lower()),
+                    key == "entries_url",
                     include_chains=True,
                     for_structure=True,
-                    base_query=sq,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -137,13 +137,18 @@ class ProteomeSerializer(ModelContentSerializer):
                 SerializerDetail.TAXONOMY_DB in detail_filters
                 or SerializerDetail.TAXONOMY_DETAIL in detail_filters
             ):
-                key = (
-                    "taxa"
-                    if SerializerDetail.TAXONOMY_DETAIL in detail_filters
-                    else "taxonomy_subset"
+                key = self.get_endpoint_key(
+                    "taxonomy",
+                    SerializerDetail.TAXONOMY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_taxonomy_detail_representation(
-                    None, self.searcher, query_searcher
+                    instance,
+                    self.searcher,
+                    query_searcher,
+                    key == "taxa_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -77,7 +77,6 @@ class ProteomeSerializer(ModelContentSerializer):
                     endpoint, query_searcher
                 )
         if detail != SerializerDetail.PROTEOME_OVERVIEW:
-            sq = self.queryset_manager.get_searcher_query()
             if (
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
@@ -92,9 +91,9 @@ class ProteomeSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     query_searcher,
+                    self.context["request"],
                     key == "entries_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters
@@ -110,10 +109,10 @@ class ProteomeSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     query_searcher,
+                    self.context["request"],
                     key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters
@@ -129,9 +128,9 @@ class ProteomeSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     query_searcher,
+                    self.context["request"],
                     key == "proteins_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters
@@ -147,8 +146,8 @@ class ProteomeSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     query_searcher,
+                    self.context["request"],
                     key == "taxa_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters
@@ -164,8 +163,8 @@ class ProteomeSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     query_searcher,
+                    self.context["request"],
                     key == "sets_url",
-                    request=self.context["request"],
                 )
         return representation
 
@@ -292,10 +291,10 @@ class ProteomeSerializer(ModelContentSerializer):
     @staticmethod
     def to_group_representation(instance):
         if "groups" in instance:
-            if ProteomeSerializer.grouper_is_empty(instance):
-                raise EmptyQuerysetError(
-                    ModelContentSerializer.NO_DATA_ERROR_MESSAGE.format("Proteome")
-                )
+            # if ProteomeSerializer.grouper_is_empty(instance):
+            #     raise EmptyQuerysetError(
+            #         ModelContentSerializer.NO_DATA_ERROR_MESSAGE.format("Proteome")
+            #     )
             return {
                 ProteomeSerializer.get_key_from_bucket(
                     bucket

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -100,17 +100,20 @@ class ProteomeSerializer(ModelContentSerializer):
                 SerializerDetail.STRUCTURE_DB in detail_filters
                 or SerializerDetail.STRUCTURE_DETAIL in detail_filters
             ):
-                key = (
-                    "structures"
-                    if SerializerDetail.STRUCTURE_DETAIL in detail_filters
-                    else "structure_subset"
+                key = self.get_endpoint_key(
+                    "structure",
+                    SerializerDetail.STRUCTURE_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_structures_detail_representation(
                     instance,
                     self.searcher,
                     query_searcher,
+                    key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -82,8 +82,11 @@ class ProteomeSerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = self.get_entries_key(
-                    detail_filters, self.queryset_manager.show_subset
+                key = self.get_endpoint_key(
+                    "entry",
+                    SerializerDetail.ENTRY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_entries_detail_representation(
                     instance,
@@ -113,16 +116,19 @@ class ProteomeSerializer(ModelContentSerializer):
                 SerializerDetail.PROTEIN_DB in detail_filters
                 or SerializerDetail.PROTEIN_DETAIL in detail_filters
             ):
-                key = (
-                    "proteins"
-                    if SerializerDetail.PROTEIN_DETAIL in detail_filters
-                    else "protein_subset"
+                key = self.get_endpoint_key(
+                    "protein",
+                    SerializerDetail.PROTEIN_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteins_detail_representation(
                     instance,
                     self.searcher,
                     query_searcher,
+                    key == "proteins_url",
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -149,13 +149,18 @@ class ProteomeSerializer(ModelContentSerializer):
                 SerializerDetail.SET_DB in detail_filters
                 or SerializerDetail.SET_DETAIL in detail_filters
             ):
-                key = (
-                    "sets"
-                    if SerializerDetail.SET_DETAIL in detail_filters
-                    else "set_subset"
+                key = self.get_endpoint_key(
+                    "set",
+                    SerializerDetail.SET_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_set_detail_representation(
-                    instance, self.searcher, query_searcher
+                    instance,
+                    self.searcher,
+                    query_searcher,
+                    key == "sets_url",
+                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/proteome.py
+++ b/webfront/serializers/proteome.py
@@ -82,17 +82,16 @@ class ProteomeSerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = (
-                    "entries"
-                    if SerializerDetail.ENTRY_DETAIL in detail_filters
-                    else "entry_subset"
+                key = self.get_entries_key(
+                    detail_filters, self.queryset_manager.show_subset
                 )
                 representation[key] = self.to_entries_detail_representation(
                     instance,
                     self.searcher,
                     query_searcher,
-                    base_query=sq,
+                    key == "entries_url",
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -122,17 +122,20 @@ class TaxonomySerializer(ModelContentSerializer):
                 SerializerDetail.STRUCTURE_DB in detail_filters
                 or SerializerDetail.STRUCTURE_DETAIL in detail_filters
             ):
-                key = (
-                    "structures"
-                    if SerializerDetail.STRUCTURE_DETAIL in detail_filters
-                    else "structure_subset"
+                key = self.get_endpoint_key(
+                    "structure",
+                    SerializerDetail.STRUCTURE_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_structures_detail_representation(
                     instance,
                     s,
                     self.get_searcher_query(instance),
+                    key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -156,13 +156,18 @@ class TaxonomySerializer(ModelContentSerializer):
                 SerializerDetail.PROTEOME_DB in detail_filters
                 or SerializerDetail.PROTEOME_DETAIL in detail_filters
             ):
-                key = (
-                    "proteomes"
-                    if SerializerDetail.PROTEOME_DETAIL in detail_filters
-                    else "proteome_subset"
+                key = self.get_endpoint_key(
+                    "proteome",
+                    SerializerDetail.PROTEOME_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteomes_detail_representation(
-                    self.searcher, self.get_searcher_query(instance)
+                    instance,
+                    self.searcher,
+                    self.get_searcher_query(instance),
+                    key == "proteomes_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -104,17 +104,16 @@ class TaxonomySerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = (
-                    "entries"
-                    if SerializerDetail.ENTRY_DETAIL in detail_filters
-                    else "entry_subset"
+                key = self.get_entries_key(
+                    detail_filters, self.queryset_manager.show_subset
                 )
                 representation[key] = self.to_entries_detail_representation(
                     instance,
                     s,
                     self.get_searcher_query(instance),
-                    base_query=sq,
+                    key == "entries_url",
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -176,13 +176,18 @@ class TaxonomySerializer(ModelContentSerializer):
                 SerializerDetail.SET_DB in detail_filters
                 or SerializerDetail.SET_DETAIL in detail_filters
             ):
-                key = (
-                    "sets"
-                    if SerializerDetail.SET_DETAIL in detail_filters
-                    else "set_subset"
+                key = self.get_endpoint_key(
+                    "set",
+                    SerializerDetail.SET_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_set_detail_representation(
-                    instance, self.searcher, self.get_searcher_query(instance)
+                    instance,
+                    self.searcher,
+                    self.get_searcher_query(instance),
+                    key == "sets_url",
+                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -114,9 +114,9 @@ class TaxonomySerializer(ModelContentSerializer):
                     instance,
                     s,
                     self.get_searcher_query(instance),
+                    self.context["request"],
                     key == "entries_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters
@@ -132,10 +132,10 @@ class TaxonomySerializer(ModelContentSerializer):
                     instance,
                     s,
                     self.get_searcher_query(instance),
+                    self.context["request"],
                     key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEIN_DB in detail_filters
@@ -151,9 +151,9 @@ class TaxonomySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     self.get_searcher_query(instance),
+                    self.context["request"],
                     key == "proteins_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters
@@ -169,8 +169,8 @@ class TaxonomySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     self.get_searcher_query(instance),
+                    self.context["request"],
                     key == "proteomes_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters
@@ -186,8 +186,8 @@ class TaxonomySerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     self.get_searcher_query(instance),
+                    self.context["request"],
                     key == "sets_url",
-                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/taxonomy.py
+++ b/webfront/serializers/taxonomy.py
@@ -104,8 +104,11 @@ class TaxonomySerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = self.get_entries_key(
-                    detail_filters, self.queryset_manager.show_subset
+                key = self.get_endpoint_key(
+                    "entry",
+                    SerializerDetail.ENTRY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_entries_detail_representation(
                     instance,
@@ -135,16 +138,19 @@ class TaxonomySerializer(ModelContentSerializer):
                 SerializerDetail.PROTEIN_DB in detail_filters
                 or SerializerDetail.PROTEIN_DETAIL in detail_filters
             ):
-                key = (
-                    "proteins"
-                    if SerializerDetail.PROTEIN_DETAIL in detail_filters
-                    else "protein_subset"
+                key = self.get_endpoint_key(
+                    "protein",
+                    SerializerDetail.PROTEIN_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteins_detail_representation(
                     instance,
                     self.searcher,
                     self.get_searcher_query(instance),
+                    key == "proteins_url",
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -141,15 +141,18 @@ class ProteinSerializer(ModelContentSerializer):
                 SerializerDetail.SET_DB in detail_filters
                 or SerializerDetail.SET_DETAIL in detail_filters
             ):
-                key = (
-                    "sets"
-                    if SerializerDetail.SET_DETAIL in detail_filters
-                    else "set_subset"
+                key = self.get_endpoint_key(
+                    "set",
+                    SerializerDetail.SET_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_set_detail_representation(
                     instance,
                     self.searcher,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    key == "sets_url",
+                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -91,17 +91,20 @@ class ProteinSerializer(ModelContentSerializer):
                 SerializerDetail.STRUCTURE_DB in detail_filters
                 or SerializerDetail.STRUCTURE_DETAIL in detail_filters
             ):
-                key = (
-                    "structures"
-                    if SerializerDetail.STRUCTURE_DETAIL in detail_filters
-                    else "structure_subset"
+                key = self.get_endpoint_key(
+                    "structure",
+                    SerializerDetail.STRUCTURE_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_structures_detail_representation(
                     instance,
                     s,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -110,15 +110,18 @@ class ProteinSerializer(ModelContentSerializer):
                 SerializerDetail.TAXONOMY_DB in detail_filters
                 or SerializerDetail.TAXONOMY_DETAIL in detail_filters
             ):
-                key = (
-                    "taxa"
-                    if SerializerDetail.TAXONOMY_DETAIL in detail_filters
-                    else "taxonomy_subset"
+                key = self.get_endpoint_key(
+                    "taxonomy",
+                    SerializerDetail.TAXONOMY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_taxonomy_detail_representation(
                     instance,
                     self.searcher,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    key == "taxa_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -83,9 +83,9 @@ class ProteinSerializer(ModelContentSerializer):
                     instance,
                     s,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "entries_url",
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters
@@ -101,10 +101,10 @@ class ProteinSerializer(ModelContentSerializer):
                     instance,
                     s,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "structures_url",
                     include_chain=True,
                     queryset_manager=self.queryset_manager,
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.TAXONOMY_DB in detail_filters
@@ -120,8 +120,8 @@ class ProteinSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "taxa_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.PROTEOME_DB in detail_filters
@@ -137,8 +137,8 @@ class ProteinSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "proteomes_url",
-                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters
@@ -154,8 +154,8 @@ class ProteinSerializer(ModelContentSerializer):
                     instance,
                     self.searcher,
                     "protein_acc:" + escape(instance.accession.lower()),
+                    self.context["request"],
                     key == "sets_url",
-                    request=self.context["request"],
                 )
         return representation
 

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -72,8 +72,11 @@ class ProteinSerializer(ModelContentSerializer):
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = self.get_entries_key(
-                    detail_filters, self.queryset_manager.show_subset
+                key = self.get_endpoint_key(
+                    "entry",
+                    SerializerDetail.ENTRY_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
 
                 representation[key] = self.to_entries_detail_representation(

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -121,13 +121,18 @@ class ProteinSerializer(ModelContentSerializer):
                 SerializerDetail.PROTEOME_DB in detail_filters
                 or SerializerDetail.PROTEOME_DETAIL in detail_filters
             ):
-                key = (
-                    "proteomes"
-                    if SerializerDetail.PROTEOME_DETAIL in detail_filters
-                    else "proteome_subset"
+                key = self.get_endpoint_key(
+                    "proteome",
+                    SerializerDetail.PROTEOME_DETAIL,
+                    detail_filters,
+                    self.queryset_manager.show_subset,
                 )
                 representation[key] = self.to_proteomes_detail_representation(
-                    self.searcher, "protein_acc:" + escape(instance.accession.lower())
+                    instance,
+                    self.searcher,
+                    "protein_acc:" + escape(instance.accession.lower()),
+                    key == "proteomes_url",
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.SET_DB in detail_filters

--- a/webfront/serializers/uniprot.py
+++ b/webfront/serializers/uniprot.py
@@ -68,22 +68,21 @@ class ProteinSerializer(ModelContentSerializer):
         if SerializerDetail.SET_OVERVIEW in detail_filters:
             representation["sets"] = self.to_set_count_representation(instance)
         if detail != SerializerDetail.PROTEIN_OVERVIEW:
-            sq = self.queryset_manager.get_searcher_query()
             if (
                 SerializerDetail.ENTRY_DB in detail_filters
                 or SerializerDetail.ENTRY_DETAIL in detail_filters
             ):
-                key = (
-                    "entries"
-                    if SerializerDetail.ENTRY_DETAIL in detail_filters
-                    else "entry_subset"
+                key = self.get_entries_key(
+                    detail_filters, self.queryset_manager.show_subset
                 )
+
                 representation[key] = self.to_entries_detail_representation(
                     instance,
                     s,
                     "protein_acc:" + escape(instance.accession.lower()),
-                    base_query=sq,
+                    key == "entries_url",
                     queryset_manager=self.queryset_manager,
+                    request=self.context["request"],
                 )
             if (
                 SerializerDetail.STRUCTURE_DB in detail_filters

--- a/webfront/tests/InterproRESTTestCase.py
+++ b/webfront/tests/InterproRESTTestCase.py
@@ -6,6 +6,9 @@ from rest_framework import status
 
 from webfront.models import TaxonomyPerEntry
 from webfront.tests.fixtures_reader import FixtureReader
+from django.core.validators import URLValidator
+
+validateURL = URLValidator()
 
 chains = {
     "1JM7": ["A", "B"],
@@ -336,6 +339,12 @@ class InterproRESTTestCase(APITransactionTestCase):
             self.assertIn(
                 element, superset, "Element {} in subset but not in set".format(element)
             )
+
+    def asserURL(self, url, msg=None):
+        try:
+            validateURL(url)
+        except:
+            raise self.failureException(msg)
 
     def _check_taxonomy_details(self, obj, is_complete=True, msg=""):
         self.assertIn("accession", obj, msg)

--- a/webfront/tests/InterproRESTTestCase.py
+++ b/webfront/tests/InterproRESTTestCase.py
@@ -320,22 +320,23 @@ class InterproRESTTestCase(APITransactionTestCase):
         url,
         endpoint,
         check_metadata_fn=None,
-        inner_subset_check_fn=None,
-        subset_check_fn=None,
+        check_subset_fn=None,
+        check_inner_subset_fn=None,
     ):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         if check_metadata_fn is not None:
             check_metadata_fn(response.data["metadata"])
         self.assertIn(f"{plurals[endpoint]}_url", response.data)
+        self.assertURL(response.data[f"{plurals[endpoint]}_url"])
         response = self.client.get(url + "?show-subset")
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(f"{endpoint}_subset", response.data)
-        if subset_check_fn is not None:
-            subset_check_fn(response.data[f"{endpoint}_subset"])
-        if inner_subset_check_fn is not None:
+        if check_subset_fn is not None:
+            check_subset_fn(response.data[f"{endpoint}_subset"])
+        if check_inner_subset_fn is not None:
             for st in response.data[f"{endpoint}_subset"]:
-                inner_subset_check_fn(st)
+                check_inner_subset_fn(st)
 
     def _check_list_url_with_and_without_subset(
         self,
@@ -344,8 +345,8 @@ class InterproRESTTestCase(APITransactionTestCase):
         check_results_fn=None,
         check_result_fn=None,
         check_metadata_fn=None,
-        inner_subset_check_fn=None,
-        subset_check_fn=None,
+        check_subset_fn=None,
+        check_inner_subset_fn=None,
     ):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
@@ -365,11 +366,11 @@ class InterproRESTTestCase(APITransactionTestCase):
                 check_result_fn(result)
             if check_metadata_fn is not None:
                 check_metadata_fn(result["metadata"])
-            if subset_check_fn is not None:
-                subset_check_fn(result[f"{endpoint}_subset"])
+            if check_subset_fn is not None:
+                check_subset_fn(result[f"{endpoint}_subset"])
             for s in result[f"{endpoint}_subset"]:
-                if inner_subset_check_fn is not None:
-                    inner_subset_check_fn(s)
+                if check_inner_subset_fn is not None:
+                    check_inner_subset_fn(s)
 
     def assertURL(self, url, msg=None):
         try:

--- a/webfront/tests/InterproRESTTestCase.py
+++ b/webfront/tests/InterproRESTTestCase.py
@@ -356,6 +356,9 @@ class InterproRESTTestCase(APITransactionTestCase):
         self._check_is_list_of_objects_with_key(
             response.data["results"], f"{plurals[endpoint]}_url"
         )
+        for result in response.data["results"]:
+            self.assertURL(result[f"{plurals[endpoint]}_url"])
+
         response = self.client.get(url + "?show-subset")
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(
@@ -400,7 +403,6 @@ class InterproRESTTestCase(APITransactionTestCase):
     def _check_proteome_details(self, obj, is_complete=True, msg=""):
         self.assertIn("accession", obj, msg)
         self.assertIn("taxonomy", obj, msg)
-        self.assertIn("is_reference", obj, msg)
         self.assertIn("name", obj, msg)
         if is_complete:
             self.assertIn("strain", obj, msg)

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -5,7 +5,7 @@ singular = {v: k for k, v in plurals.items()}
 for s in plurals.keys():
     singular[s + "_subset"] = s
 
-endpoints_with_url = ["entry", "protein"]
+endpoints_with_url = ["entry", "protein", "proteome"]
 
 
 # value: * all that have the field, None all that don't have the field

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -5,6 +5,8 @@ singular = {v: k for k, v in plurals.items()}
 for s in plurals.keys():
     singular[s + "_subset"] = s
 
+endpoints_with_url = ["entry", "protein"]
+
 
 # value: * all that have the field, None all that don't have the field
 def filter_by_value(docs, field, value):
@@ -383,9 +385,9 @@ def extend_obj_with_other_endpoints(data, endpoints, dbs, accs, instance, ep):
             )[
                 :20
             ]  # the API only returns up to 20 items in a sublist
-            if current_ep == "entry" and current_acc is None:
+            if current_ep in endpoints_with_url and current_acc is None:
                 del instance[key]
-                key = "entries_url"
+                key = f"{plurals[current_ep]}_url"
                 instance[key] = "URL TO BE DEFINED"
 
 

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -5,7 +5,7 @@ singular = {v: k for k, v in plurals.items()}
 for s in plurals.keys():
     singular[s + "_subset"] = s
 
-endpoints_with_url = ["entry", "protein", "structure", "proteome"]
+endpoints_with_url = ["entry", "protein", "structure", "proteome", "set"]
 
 
 # value: * all that have the field, None all that don't have the field

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -383,7 +383,7 @@ def extend_obj_with_other_endpoints(data, endpoints, dbs, accs, instance, ep):
             )[
                 :20
             ]  # the API only returns up to 20 items in a sublist
-            if current_ep == "entry":
+            if current_ep == "entry" and current_acc is None:
                 del instance[key]
                 key = "entries_url"
                 instance[key] = "URL TO BE DEFINED"

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -5,8 +5,6 @@ singular = {v: k for k, v in plurals.items()}
 for s in plurals.keys():
     singular[s + "_subset"] = s
 
-endpoints_with_url = ["entry", "protein", "structure", "taxonomy", "proteome", "set"]
-
 
 # value: * all that have the field, None all that don't have the field
 def filter_by_value(docs, field, value):
@@ -374,21 +372,19 @@ def extend_obj_with_other_endpoints(data, endpoints, dbs, accs, instance, ep):
         else:
             key = plurals[current_ep]
             if current_acc is None:
-                key = current_ep + "_subset"
-            instance[key] = get_payload_list(
-                data,
-                current_ep,
-                current_db,
-                False,
-                ep == "structure"
-                or current_ep == "structure",  # and current_acc is None
-            )[
-                :20
-            ]  # the API only returns up to 20 items in a sublist
-            if current_ep in endpoints_with_url and current_acc is None:
-                del instance[key]
                 key = f"{plurals[current_ep]}_url"
                 instance[key] = "URL TO BE DEFINED"
+            else:
+                instance[key] = get_payload_list(
+                    data,
+                    current_ep,
+                    current_db,
+                    False,
+                    ep == "structure"
+                    or current_ep == "structure",  # and current_acc is None
+                )[
+                    :20
+                ]  # the API only returns up to 20 items in a sublist
 
 
 def get_db_payload(data, endpoints, dbs, accs=None):

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -5,7 +5,7 @@ singular = {v: k for k, v in plurals.items()}
 for s in plurals.keys():
     singular[s + "_subset"] = s
 
-endpoints_with_url = ["entry", "protein", "proteome"]
+endpoints_with_url = ["entry", "protein", "structure", "proteome"]
 
 
 # value: * all that have the field, None all that don't have the field

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -5,7 +5,7 @@ singular = {v: k for k, v in plurals.items()}
 for s in plurals.keys():
     singular[s + "_subset"] = s
 
-endpoints_with_url = ["entry", "protein", "structure", "proteome", "set"]
+endpoints_with_url = ["entry", "protein", "structure", "taxonomy", "proteome", "set"]
 
 
 # value: * all that have the field, None all that don't have the field

--- a/webfront/tests/actions_on_test_dataset.py
+++ b/webfront/tests/actions_on_test_dataset.py
@@ -383,6 +383,10 @@ def extend_obj_with_other_endpoints(data, endpoints, dbs, accs, instance, ep):
             )[
                 :20
             ]  # the API only returns up to 20 items in a sublist
+            if current_ep == "entry":
+                del instance[key]
+                key = "entries_url"
+                instance[key] = "URL TO BE DEFINED"
 
 
 def get_db_payload(data, endpoints, dbs, accs=None):

--- a/webfront/tests/fixtures_reader.py
+++ b/webfront/tests/fixtures_reader.py
@@ -100,8 +100,6 @@ class FixtureReader:
             for n in self.sets[s]["relationships"]["nodes"]:
                 if n["type"] == "entry":
                     db = self.sets[s]["source_database"]
-                    # if db == "node":
-                    #     db = "kegg"
                     if n["accession"].lower() not in e2s:
                         e2s[n["accession"].lower()] = []
                     e2s[n["accession"].lower()].append(

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -775,27 +775,21 @@ class SetStructureTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_list(self):
         urls = ["/api/set/pfam/structure/pdb"]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "structure",
+                inner_subset_check_fn=self._check_structure_chain_details,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "structure_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["structure_subset"]:
-                    self._check_structure_chain_details(s)
 
     def test_can_get_a_list_from_the_set_object(self):
         urls = ["/api/set/pfam/Cl0001/structure/pdb"]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_set_details(response.data["metadata"], True)
-            self.assertIn("structure_subset", response.data)
-            for st in response.data["structure_subset"]:
-                self._check_structure_chain_details(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "structure",
+                check_metadata_fn=lambda m: self._check_set_details(m, True),
+                inner_subset_check_fn=self._check_structure_chain_details,
+            )
 
     def test_can_filter_set_counter_with_acc(self):
         urls = ["/api/set/structure/pdb/1JM7", "/api/set/structure/pdb/2bkm"]

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -707,17 +707,6 @@ class SetStructureTest(InterproRESTTestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
-            if "kegg" in response.data["sets"]:
-                self.assertIn(
-                    "structures",
-                    response.data["sets"]["kegg"],
-                    "'structures' should be one of the keys in the response",
-                )
-                self.assertIn(
-                    "sets",
-                    response.data["sets"]["kegg"],
-                    "'sets' should be one of the keys in the response",
-                )
             if "pfam" in response.data["sets"]:
                 self.assertIn(
                     "structures",

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -108,7 +108,7 @@ class EntrySetTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
             )
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
@@ -120,7 +120,7 @@ class EntrySetTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
                 check_metadata_fn=self._check_entry_details,
             )
 
@@ -265,7 +265,7 @@ class ProteinSetTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
             )
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
@@ -277,7 +277,7 @@ class ProteinSetTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
                 check_metadata_fn=self._check_protein_details,
             )
 
@@ -372,7 +372,7 @@ class StructureSetTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
             )
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
@@ -381,7 +381,7 @@ class StructureSetTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
                 check_metadata_fn=self._check_structure_details,
             )
 
@@ -484,7 +484,7 @@ class SetEntryTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
             )
 
     def test_can_get_a_list_from_the_set_object(self):
@@ -497,7 +497,7 @@ class SetEntryTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
                 check_metadata_fn=self._check_set_details,
             )
 
@@ -605,21 +605,13 @@ class SetProteinTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_list(self):
         urls = ["/api/set/pfam/protein/reviewed"]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=lambda p: self._check_match(
+                    p, include_coordinates=False
+                ),
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteins_url"
-            )
-            response = self.client.get(url + "?show-subset")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "protein_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["protein_subset"]:
-                    self._check_match(s, include_coordinates=False)
 
     def test_can_get_a_list_from_the_set_object(self):
         urls = [
@@ -627,14 +619,16 @@ class SetProteinTest(InterproRESTTestCase):
             "/api/set/pfam/CL0001/protein/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_set_details(response.data["metadata"], True)
-            self.assertIn("proteins_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertIn("protein_subset", response.data)
-            for st in response.data["protein_subset"]:
-                self._check_match(st, include_coordinates=False)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=lambda p: self._check_match(
+                    p, include_coordinates=False
+                ),
+                check_metadata_fn=self._check_set_details,
+            )
+
+    # TODO: 📝 Replace the rest of tests like the 2 ones above
 
     def test_can_filter_set_counter_with_acc(self):
         urls = ["/api/set/protein/uniprot/M5ADK6", "/api/set/protein/reviewed/M5ADK6"]
@@ -742,7 +736,7 @@ class SetStructureTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "structure",
-                inner_subset_check_fn=self._check_structure_chain_details,
+                check_inner_subset_fn=self._check_structure_chain_details,
             )
 
     def test_can_get_a_list_from_the_set_object(self):
@@ -752,7 +746,7 @@ class SetStructureTest(InterproRESTTestCase):
                 url,
                 "structure",
                 check_metadata_fn=lambda m: self._check_set_details(m, True),
-                inner_subset_check_fn=self._check_structure_chain_details,
+                check_inner_subset_fn=self._check_structure_chain_details,
             )
 
     def test_can_filter_set_counter_with_acc(self):

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -105,17 +105,11 @@ class EntrySetTest(InterproRESTTestCase):
             f"/api/entry/interpro/{acc}/pfam/set/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "set_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["set_subset"]:
-                    self._check_set_from_searcher(s)
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
         urls = [
@@ -123,12 +117,12 @@ class EntrySetTest(InterproRESTTestCase):
             "/api/entry/unintegrated/pfam/PF17176/set/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_entry_details(response.data["metadata"])
-            self.assertIn("set_subset", response.data)
-            for org in response.data["set_subset"]:
-                self._check_set_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
+                check_metadata_fn=self._check_entry_details,
+            )
 
     def test_can_filter_entry_counter_with_set_acc(self):
         urls = ["/api/entry/set/pfam/Cl0001", "/api/entry/set/pfam/Cl0002"]
@@ -268,17 +262,11 @@ class ProteinSetTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_list(self):
         urls = ["/api/protein/reviewed/set/pfam"]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "set_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["set_subset"]:
-                    self._check_set_from_searcher(s)
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
         urls = [
@@ -286,12 +274,12 @@ class ProteinSetTest(InterproRESTTestCase):
             "/api/protein/reviewed/A1CUJ5/set/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_protein_details(response.data["metadata"])
-            self.assertIn("set_subset", response.data)
-            for s in response.data["set_subset"]:
-                self._check_set_from_searcher(s)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
+                check_metadata_fn=self._check_protein_details,
+            )
 
     def test_can_filter_counter_with_set_acc(self):
         urls = ["/api/protein/set/pfam/Cl0001"]
@@ -381,27 +369,21 @@ class StructureSetTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_list(self):
         urls = ["/api/structure/pdb/set/pfam"]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "set_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["set_subset"]:
-                    self._check_set_from_searcher(s)
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
         urls = ["/api/structure/pdb/1JM7/set/pfam"]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_structure_details(response.data["metadata"])
-            self.assertIn("set_subset", response.data)
-            for s in response.data["set_subset"]:
-                self._check_set_from_searcher(s)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
+                check_metadata_fn=self._check_structure_details,
+            )
 
     def test_can_filter_counter_with_set_acc(self):
         urls = ["/api/structure/set/pfam/Cl0001"]

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -565,6 +565,16 @@ class SetEntryTest(InterproRESTTestCase):
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
+                response.data["results"], "entries_url"
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
+            )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "metadata"
+            )
+            self._check_is_list_of_objects_with_key(
                 response.data["results"], "entry_subset"
             )
             for result in response.data["results"]:
@@ -579,6 +589,12 @@ class SetEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
+            )
+            self._check_set_details(response.data["metadata"], True)
+            self.assertIn("entries_url", response.data)
+            response = self.client.get(url + "?show-subset")
             self.assertEqual(
                 response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
             )

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -46,13 +46,11 @@ class EntrySetTest(InterproRESTTestCase):
             "/api/entry/unintegrated/set",
             "/api/entry/interpro/pfam/set",
             "/api/entry/unintegrated/pfam/set",
-            "/api/entry/interpro/" + acc + "/pfam/set",
+            f"/api/entry/interpro/{acc}/pfam/set",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -65,17 +63,15 @@ class EntrySetTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/entry/pfam/" + pfam + "/set",
-            "/api/entry/pfam/" + pfam_un + "/set",
-            "/api/entry/interpro/" + acc + "/pfam/" + pfam + "/set",
-            "/api/entry/interpro/pfam/" + pfam + "/set",
-            "/api/entry/unintegrated/pfam/" + pfam_un + "/set",
+            f"/api/entry/pfam/{pfam}/set",
+            f"/api/entry/pfam/{pfam_un}/set",
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/set",
+            f"/api/entry/interpro/pfam/{pfam}/set",
+            f"/api/entry/unintegrated/pfam/{pfam_un}/set",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn(
                 "sets",
@@ -88,9 +84,7 @@ class EntrySetTest(InterproRESTTestCase):
         urls = ["/api/entry/set/pfam"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn(
                 "sets",
                 response.data["entries"]["integrated"],
@@ -108,13 +102,11 @@ class EntrySetTest(InterproRESTTestCase):
         urls = [
             "/api/entry/pfam/set/pfam",
             "/api/entry/unintegrated/set/pfam",
-            "/api/entry/interpro/" + acc + "/pfam/set/pfam",
+            f"/api/entry/interpro/{acc}/pfam/set/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -132,9 +124,7 @@ class EntrySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn("set_subset", response.data)
             for org in response.data["set_subset"]:
@@ -144,9 +134,7 @@ class EntrySetTest(InterproRESTTestCase):
         urls = ["/api/entry/set/pfam/Cl0001", "/api/entry/set/pfam/Cl0002"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
@@ -157,9 +145,7 @@ class EntrySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -175,9 +161,7 @@ class EntrySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn("sets", response.data)
             for s in response.data["sets"]:
@@ -186,9 +170,7 @@ class EntrySetTest(InterproRESTTestCase):
     def test_can_get_the_authors_and_literature(self):
         url = "/api/set/pfam/CL0001"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         metadata = response.data["metadata"]
         self._check_set_details(metadata)
         self.assertIn("authors", metadata)
@@ -201,9 +183,7 @@ class EntrySetTest(InterproRESTTestCase):
     def test_can_authors_and_literature_be_null(self):
         url = "/api/set/pfam/CL0002"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         metadata = response.data["metadata"]
         self._check_set_details(metadata)
         self.assertIn("authors", metadata)
@@ -222,9 +202,7 @@ class ProteinSetTest(InterproRESTTestCase):
         urls = ["/api/protein/reviewed/set/", "/api/protein/uniprot/set/"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -235,14 +213,12 @@ class ProteinSetTest(InterproRESTTestCase):
     def test_urls_that_return_protein_with_set_count(self):
         reviewed = "A1CUJ5"
         urls = [
-            "/api/protein/uniprot/" + reviewed + "/set",
-            "/api/protein/reviewed/" + reviewed + "/set",
+            f"/api/protein/uniprot/{reviewed}/set",
+            f"/api/protein/reviewed/{reviewed}/set",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn(
                 "sets",
@@ -255,9 +231,7 @@ class ProteinSetTest(InterproRESTTestCase):
         urls = ["/api/protein/set/pfam"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn(
                 "proteins",
                 response.data["proteins"]["uniprot"],
@@ -295,9 +269,7 @@ class ProteinSetTest(InterproRESTTestCase):
         urls = ["/api/protein/reviewed/set/pfam"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -315,9 +287,7 @@ class ProteinSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn("set_subset", response.data)
             for s in response.data["set_subset"]:
@@ -327,9 +297,7 @@ class ProteinSetTest(InterproRESTTestCase):
         urls = ["/api/protein/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
@@ -339,9 +307,7 @@ class ProteinSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -357,9 +323,7 @@ class ProteinSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn("sets", response.data)
             for s in response.data["sets"]:
@@ -377,9 +341,7 @@ class StructureSetTest(InterproRESTTestCase):
         urls = ["/api/structure/pdb/set/"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -388,12 +350,10 @@ class StructureSetTest(InterproRESTTestCase):
                 self._check_set_count_overview(result)
 
     def test_urls_that_return_structure_with_set_count(self):
-        urls = ["/api/structure/pdb/" + pdb + "/set/" for pdb in ["1JM7", "2BKM"]]
+        urls = [f"/api/structure/pdb/{pdb}/set/" for pdb in ["1JM7", "2BKM"]]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn(
                 "sets",
@@ -406,9 +366,7 @@ class StructureSetTest(InterproRESTTestCase):
         urls = ["/api/structure/set/pfam"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn(
                 "structures",
                 response.data["structures"]["pdb"],
@@ -424,9 +382,7 @@ class StructureSetTest(InterproRESTTestCase):
         urls = ["/api/structure/pdb/set/pfam"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -441,9 +397,7 @@ class StructureSetTest(InterproRESTTestCase):
         urls = ["/api/structure/pdb/1JM7/set/pfam"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn("set_subset", response.data)
             for s in response.data["set_subset"]:
@@ -453,18 +407,14 @@ class StructureSetTest(InterproRESTTestCase):
         urls = ["/api/structure/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
         urls = ["/api/structure/pdb/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -477,9 +427,7 @@ class StructureSetTest(InterproRESTTestCase):
         urls = ["/api/structure/pdb/1JM7/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn("sets", response.data)
             for s in response.data["sets"]:
@@ -497,9 +445,7 @@ class SetEntryTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/entry"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -511,9 +457,7 @@ class SetEntryTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/CL0001/entry"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn(
                 "entries",
@@ -529,13 +473,11 @@ class SetEntryTest(InterproRESTTestCase):
             "/api/set/entry/unintegrated",
             "/api/set/entry/unintegrated/pfam",
             "/api/set/entry/interpro/pfam",
-            "/api/set/entry/interpro/" + acc + "/pfam",
+            f"/api/set/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             if "pfam" in response.data["sets"]:
                 self.assertIn(
@@ -554,23 +496,19 @@ class SetEntryTest(InterproRESTTestCase):
         urls = [
             "/api/set/pfam/entry/pfam",
             "/api/set/pfam/entry/unintegrated",
-            "/api/set/pfam/entry/interpro/" + acc + "/pfam",
+            f"/api/set/pfam/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "entries_url"
             )
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            response = self.client.get(f"{url}?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -589,15 +527,11 @@ class SetEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
             self.assertIn("entries_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            response = self.client.get(f"{url}?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
             self.assertIn("entry_subset", response.data)
             for st in response.data["entry_subset"]:
@@ -608,31 +542,27 @@ class SetEntryTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/set/entry/pfam/" + pfam,
-            "/api/set/entry/pfam/" + pfam_un,
-            "/api/set/entry/interpro/" + acc + "/pfam/" + pfam,
-            "/api/set/entry/interpro/pfam/" + pfam,
-            "/api/set/entry/unintegrated/pfam/" + pfam_un,
+            f"/api/set/entry/pfam/{pfam}",
+            f"/api/set/entry/pfam/{pfam_un}",
+            f"/api/set/entry/interpro/{acc}/pfam/{pfam}",
+            f"/api/set/entry/interpro/pfam/{pfam}",
+            f"/api/set/entry/unintegrated/pfam/{pfam_un}",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_count_overview(response.data)
 
     def test_can_get_object_on_a_set_list(self):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/set/pfam/entry/unintegrated/pfam/" + pfam_un,
-            "/api/set/pfam/entry/integrated/pfam/" + pfam,
+            f"/api/set/pfam/entry/unintegrated/pfam/{pfam_un}",
+            f"/api/set/pfam/entry/integrated/pfam/{pfam}",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -649,9 +579,7 @@ class SetEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn("entries", response.data)
             for s in response.data["entries"]:
@@ -669,9 +597,7 @@ class SetProteinTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/protein"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -685,9 +611,7 @@ class SetProteinTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/CL0001/protein"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn(
                 "proteins",
@@ -700,9 +624,7 @@ class SetProteinTest(InterproRESTTestCase):
         urls = ["/api/set/protein/uniprot", "/api/set/protein/reviewed"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             if "pfam" in response.data["sets"]:
                 self.assertIn(
@@ -720,12 +642,14 @@ class SetProteinTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/protein/reviewed"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "proteins_url"
+            )
+            response = self.client.get(url + "?show-subset")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "protein_subset"
             )
@@ -740,10 +664,10 @@ class SetProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
+            self.assertIn("proteins_url", response.data)
+            response = self.client.get(url + "?show-subset")
             self.assertIn("protein_subset", response.data)
             for st in response.data["protein_subset"]:
                 self._check_match(st, include_coordinates=False)
@@ -752,18 +676,14 @@ class SetProteinTest(InterproRESTTestCase):
         urls = ["/api/set/protein/uniprot/M5ADK6", "/api/set/protein/reviewed/M5ADK6"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_count_overview(response.data)
 
     def test_can_get_object_on_a_set_list(self):
         urls = ["/api/set/pfam/protein/uniprot/a1cuj5"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -782,9 +702,7 @@ class SetProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn("proteins", response.data)
             for s in response.data["proteins"]:
@@ -802,9 +720,7 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/structure"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -818,9 +734,7 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/CL0001/structure"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn(
                 "structures",
@@ -833,9 +747,7 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/structure/pdb"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             if "kegg" in response.data["sets"]:
                 self.assertIn(
@@ -864,9 +776,7 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/structure/pdb"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -881,9 +791,7 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/Cl0001/structure/pdb"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
             self.assertIn("structure_subset", response.data)
             for st in response.data["structure_subset"]:
@@ -893,18 +801,14 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/structure/pdb/1JM7", "/api/set/structure/pdb/2bkm"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_count_overview(response.data)
 
     def test_can_get_object_on_a_set_list(self):
         urls = ["/api/set/pfam/structure/pdb/1JM7"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -920,9 +824,7 @@ class SetStructureTest(InterproRESTTestCase):
         urls = ["/api/set/pfam/Cl0001/structure/pdb/1JM7"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn("structures", response.data)
             for s in response.data["structures"]:
@@ -932,11 +834,11 @@ class SetStructureTest(InterproRESTTestCase):
 class SetAlignmentTests(InterproRESTTestCase):
     def test_can_get_the_set_alignments(self):
         clan = "cl0001"
-        response = self.client.get("/api/set/pfam/" + clan + "?alignments")
+        response = self.client.get(f"/api/set/pfam/{clan}?alignments")
         self.assertEqual(response.status_code, status.HTTP_410_GONE)
 
     def test_can_get_the_set_alignment(self):
         clan = "cl0001"
         pfam = "pf02171"
-        response = self.client.get("/api/set/pfam/" + clan + "?alignments=" + pfam)
+        response = self.client.get(f"/api/set/pfam/{clan}?alignments={pfam}")
         self.assertEqual(response.status_code, status.HTTP_410_GONE)

--- a/webfront/tests/test_sets.py
+++ b/webfront/tests/test_sets.py
@@ -481,25 +481,11 @@ class SetEntryTest(InterproRESTTestCase):
             f"/api/set/pfam/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "entry",
+                inner_subset_check_fn=self._check_entry_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "entries_url"
-            )
-            response = self.client.get(f"{url}?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
-            )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "entry_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["entry_subset"]:
-                    self._check_entry_from_searcher(s)
 
     def test_can_get_a_list_from_the_set_object(self):
         urls = [
@@ -508,16 +494,12 @@ class SetEntryTest(InterproRESTTestCase):
             "/api/set/pfam/CL0001/entry/unintegrated/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_set_details(response.data["metadata"], True)
-            self.assertIn("entries_url", response.data)
-            response = self.client.get(f"{url}?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_set_details(response.data["metadata"], True)
-            self.assertIn("entry_subset", response.data)
-            for st in response.data["entry_subset"]:
-                self._check_entry_from_searcher(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "entry",
+                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_metadata_fn=self._check_set_details,
+            )
 
     def test_can_filter_set_counter_with_acc(self):
         acc = "IPR003165"

--- a/webfront/tests/tests_3_endpoints_using_searcher.py
+++ b/webfront/tests/tests_3_endpoints_using_searcher.py
@@ -7,6 +7,9 @@ from rest_framework import status
 from webfront.tests.InterproRESTTestCase import InterproRESTTestCase
 from webfront.searcher.elastic_controller import ElasticsearchController
 from webfront.tests.actions_on_test_dataset import *
+from django.core.validators import URLValidator
+
+validateURL = URLValidator()
 
 api_test_map = {
     "entry": {
@@ -668,9 +671,21 @@ class ThreeEndpointsTableTest(InterproRESTTestCase):
                             key, endpoint1, obj_expected["metadata"]["accession"], url
                         ),
                     )
+                elif type(obj_expected[key]) == str:
+                    self.assertIn("_url", key)
+                    try:
+                        validateURL(obj_response[key])
+                    except:
+                        raise self.failureException(
+                            f"The URL in {key}: {obj_response[key]} is not valid"
+                        )
                 else:
-                    self.assertEqual(type(obj_expected[key]), list)
-                    self.assertEqual(type(obj_response[key]), list)
+                    self.assertEqual(
+                        type(obj_expected[key]), list, "URL: {}".format(url)
+                    )
+                    self.assertEqual(
+                        type(obj_response[key]), list, "URL: {}".format(url)
+                    )
                     self.assertEqual(
                         len(obj_response[key]),
                         len(obj_expected[key]),
@@ -699,7 +714,7 @@ class ThreeEndpointsTableTest(InterproRESTTestCase):
             obj_expected = expected[i]
             obj_response = response.data["results"][i]
             self.assert_obj_response_is_as_expected(
-                obj_expected, obj_response, endpoint1, url
+                obj_response, obj_expected, endpoint1, url
             )
 
     def test_db_db_endpoint(self):

--- a/webfront/tests/tests_3_endpoints_using_searcher.py
+++ b/webfront/tests/tests_3_endpoints_using_searcher.py
@@ -673,11 +673,12 @@ class ThreeEndpointsTableTest(InterproRESTTestCase):
                     )
                 elif type(obj_expected[key]) == str:
                     self.assertIn("_url", key)
+                    self.assertIn(key, obj_response, "URL: {}".format(url))
                     try:
                         validateURL(obj_response[key])
                     except:
                         raise self.failureException(
-                            f"The URL in {key}: {obj_response[key]} is not valid"
+                            f"The URL in {key}: {obj_response[key]} is not valid | URL: {url}"
                         )
                 else:
                     self.assertEqual(
@@ -829,13 +830,13 @@ class ThreeEndpointsTableTest(InterproRESTTestCase):
                                     )
 
     def test_db_db_acc(self):
-        for endpoint1 in api_test_map:
+        for endpoint1 in ["protein"]:  # api_test_map:
             for db1 in api_test_map[endpoint1]:
-                for endpoint2 in api_test_map:
+                for endpoint2 in ["structure"]:  # api_test_map:
                     if endpoint1 == endpoint2:
                         continue
                     for db2 in api_test_map[endpoint2]:
-                        for endpoint3 in api_test_map:
+                        for endpoint3 in ["entry"]:  # api_test_map:
                             if endpoint1 == endpoint3 or endpoint2 == endpoint3:
                                 continue
                             for db3 in api_test_map[endpoint3]:

--- a/webfront/tests/tests_entry_endpoint_protein_filter.py
+++ b/webfront/tests/tests_entry_endpoint_protein_filter.py
@@ -22,7 +22,7 @@ class EntryWithFilterProteinRESTTest(InterproRESTTestCase):
             "/api/entry/unintegrated/protein/",
             "/api/entry/interpro/pfam/protein/",
             "/api/entry/unintegrated/pfam/protein/",
-            "/api/entry/interpro/" + acc + "/pfam/protein",
+            f"/api/entry/interpro/{acc}/pfam/protein",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -36,12 +36,12 @@ class EntryWithFilterProteinRESTTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/entry/interpro/" + acc + "/protein",
-            "/api/entry/pfam/" + pfam + "/protein/",
-            "/api/entry/pfam/" + pfam_un + "/protein/",
-            "/api/entry/interpro/" + acc + "/pfam/" + pfam + "/protein/",
-            "/api/entry/interpro/pfam/" + pfam + "/protein/",
-            "/api/entry/unintegrated/pfam/" + pfam_un + "/protein/",
+            f"/api/entry/interpro/{acc}/protein",
+            f"/api/entry/pfam/{pfam}/protein/",
+            f"/api/entry/pfam/{pfam_un}/protein/",
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/protein/",
+            f"/api/entry/interpro/pfam/{pfam}/protein/",
+            f"/api/entry/unintegrated/pfam/{pfam_un}/protein/",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -75,7 +75,7 @@ class EntryWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
         # self.assertEqual(uniprots, reviewed+unreviewed, "uniprot proteins should be equal to reviewed + unreviewed")
 
     def test_can_get_proteins_from_interpro_protein(self):
-        response = self.client.get("/api/entry/interpro/protein/uniprot")
+        response = self.client.get("/api/entry/interpro/protein/uniprot?show-subset")
         self.assertEqual(len(response.data["results"]), 2)
         has_one = False
         has_two = False
@@ -93,7 +93,7 @@ class EntryWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
         )
 
     def test_can_get_reviewed_from_interpro_protein(self):
-        response = self.client.get("/api/entry/interpro/protein/reviewed")
+        response = self.client.get("/api/entry/interpro/protein/reviewed?show-subset")
         self.assertEqual(len(response.data["results"]), 2)
         has_one = False
         has_two = False
@@ -114,18 +114,20 @@ class EntryWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_u = "PF17180"
         tests = {
-            "/api/entry/interpro/" + acc + "/protein/uniprot": ["A1CUJ5", "P16582"],
-            "/api/entry/interpro/" + acc + "/protein/reviewed": ["A1CUJ5"],
-            "/api/entry/interpro/"
-            + acc
-            + "/pfam/"
-            + pfam
-            + "/protein/uniprot": ["A1CUJ5"],
-            "/api/entry/pfam/" + pfam + "/protein/uniprot": ["A1CUJ5"],
-            "/api/entry/unintegrated/pfam/" + pfam_u + "/protein/uniprot": ["M5ADK6"],
+            f"/api/entry/interpro/{acc}/protein/uniprot": ["A1CUJ5", "P16582"],
+            f"/api/entry/interpro/{acc}/protein/reviewed": ["A1CUJ5"],
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/protein/uniprot": ["A1CUJ5"],
+            f"/api/entry/pfam/{pfam}/protein/uniprot": ["A1CUJ5"],
+            f"/api/entry/unintegrated/pfam/{pfam_u}/protein/uniprot": ["M5ADK6"],
         }
         for url in tests:
             response = self.client.get(url)
+            self.assertIn(
+                "proteins_url",
+                response.data,
+                "'proteins_url' should be one of the keys in the response",
+            )
+            response = self.client.get(f"{url}?show-subset")
             self.assertIn(
                 "protein_subset",
                 response.data,
@@ -141,7 +143,7 @@ class EntryWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
 class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
     def test_can_get_entry_overview_filtered_by_protein(self):
         prot_s = "M5ADK6"
-        tests = ["/api/entry/protein/uniprot/" + prot_s]
+        tests = [f"/api/entry/protein/uniprot/{prot_s}"]
         for url in tests:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -155,19 +157,13 @@ class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         prot_u = "M5ADK6"
 
         tests = {
-            "/api/entry/interpro/" + acc + "/protein/uniprot/" + prot: ["A1CUJ5"],
-            "/api/entry/interpro/" + acc + "/protein/reviewed/" + prot: ["A1CUJ5"],
-            "/api/entry/interpro/"
-            + acc
-            + "/pfam/"
-            + pfam
-            + "/protein/uniprot/"
-            + prot: ["A1CUJ5"],
-            "/api/entry/pfam/" + pfam + "/protein/uniprot/" + prot: ["A1CUJ5"],
-            "/api/entry/unintegrated/pfam/"
-            + pfam_u
-            + "/protein/uniprot/"
-            + prot_u: ["M5ADK6"],
+            f"/api/entry/interpro/{acc}/protein/uniprot/{prot}": ["A1CUJ5"],
+            f"/api/entry/interpro/{acc}/protein/reviewed/{prot}": ["A1CUJ5"],
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/protein/uniprot/{prot}": ["A1CUJ5"],
+            f"/api/entry/pfam/{pfam}/protein/uniprot/{prot}": ["A1CUJ5"],
+            f"/api/entry/unintegrated/pfam/{pfam_u}/protein/uniprot/{prot_u}": [
+                "M5ADK6"
+            ],
         }
         for url in tests:
             response = self.client.get(url)
@@ -177,7 +173,7 @@ class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
                 "'proteins' should be one of the keys in the response",
             )
             self.assertEqual(
-                len(response.data["proteins"]), len(tests[url]), "failed at " + url
+                len(response.data["proteins"]), len(tests[url]), f"failed at {url}"
             )
             for match in response.data["proteins"]:
                 self._check_match(match)
@@ -191,12 +187,12 @@ class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         prot_u = "M5ADK6"
 
         tests = {
-            "/api/entry/interpro/protein/uniprot/" + prot: ["A1CUJ5"],
-            "/api/entry/interpro/protein/reviewed/" + prot: ["A1CUJ5"],
-            "/api/entry/interpro/" + acc + "/pfam//protein/uniprot/" + prot: ["A1CUJ5"],
-            "/api/entry/pfam/protein/uniprot/" + prot: ["A1CUJ5"],
-            "/api/entry/unintegrated/pfam/protein/uniprot/" + prot_u: ["M5ADK6"],
-            "/api/entry/panther/protein/uniprot/" + prot_u: ["M5ADK6"],
+            f"/api/entry/interpro/protein/uniprot/{prot}": ["A1CUJ5"],
+            f"/api/entry/interpro/protein/reviewed/{prot}": ["A1CUJ5"],
+            f"/api/entry/interpro/{acc}/pfam//protein/uniprot/{prot}": ["A1CUJ5"],
+            f"/api/entry/pfam/protein/uniprot/{prot}": ["A1CUJ5"],
+            f"/api/entry/unintegrated/pfam/protein/uniprot/{prot_u}": ["M5ADK6"],
+            f"/api/entry/panther/protein/uniprot/{prot_u}": ["M5ADK6"],
         }
         for url in tests:
             response = self.client.get(url)
@@ -222,21 +218,16 @@ class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         prot_u = "M5ADK6"
         smart = "SM00002"
         tests = [
-            "/api/entry/interpro/protein/uniprot/" + prot_u,
-            "/api/entry/interpro/" + acc + "/protein/unreviewed/" + prot,
-            "/api/entry/interpro/"
-            + acc
-            + "/pfam/"
-            + pfam
-            + "/protein/unreviewed/"
-            + prot,
-            "/api/entry/unintegrated/pfam/" + pfam_u + "/protein/uniprot/" + prot,
-            "/api/entry/unintegrated/pfam/" + pfam_u + "/protein/unreviewed/" + prot_u,
-            "/api/entry/unintegrated/smart/" + smart + "/protein/uniprot",
+            f"/api/entry/interpro/protein/uniprot/{prot_u}",
+            f"/api/entry/interpro/{acc}/protein/unreviewed/{prot}",
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/protein/unreviewed/{prot}",
+            f"/api/entry/unintegrated/pfam/{pfam_u}/protein/uniprot/{prot}",
+            f"/api/entry/unintegrated/pfam/{pfam_u}/protein/unreviewed/{prot_u}",
+            f"/api/entry/unintegrated/smart/{smart}/protein/uniprot",
         ]
         for url in tests:
             self._check_HTTP_response_code(
-                url, msg="The URL [" + url + "] should've failed."
+                url, msg=f"The URL [{url}] should've failed."
             )
 
     def test_urls_that_should_fail(self):
@@ -244,17 +235,12 @@ class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         pfam = "PF02171"
         prot = "A1CUJ5"
         tests = [
-            "/api/entry/interpro/"
-            + acc
-            + "/smart/"
-            + pfam
-            + "/protein/unreviewed/"
-            + prot,
-            "/api/entry/unintegrated/pfam/" + pfam + "/protein/unreviewed/" + prot,
+            f"/api/entry/interpro/{acc}/smart/{pfam}/protein/unreviewed/{prot}",
+            f"/api/entry/unintegrated/pfam/{pfam}/protein/unreviewed/{prot}",
         ]
         for url in tests:
             self._check_HTTP_response_code(
                 url,
                 code=status.HTTP_204_NO_CONTENT,
-                msg="The URL [" + url + "] should've failed.",
+                msg=f"The URL [{url}] should've failed.",
             )

--- a/webfront/tests/tests_entry_endpoint_protein_filter.py
+++ b/webfront/tests/tests_entry_endpoint_protein_filter.py
@@ -64,15 +64,6 @@ class EntryWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
             response.data["entries"]["unintegrated"],
             "'proteins' should be one of the keys in the response",
         )
-        # TODO: Improve this test
-        # uniprots = response.data["proteins"]
-        # response = self.client.get("/api/entry/protein/reviewed")
-        # self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # reviewed = response.data["proteins"]
-        # response = self.client.get("/api/entry/protein/unreviewed")
-        # self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # unreviewed = response.data["proteins"]
-        # self.assertEqual(uniprots, reviewed+unreviewed, "uniprot proteins should be equal to reviewed + unreviewed")
 
     def test_can_get_proteins_from_interpro_protein(self):
         response = self.client.get("/api/entry/interpro/protein/uniprot?show-subset")
@@ -121,23 +112,18 @@ class EntryWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
             f"/api/entry/unintegrated/pfam/{pfam_u}/protein/uniprot": ["M5ADK6"],
         }
         for url in tests:
-            response = self.client.get(url)
-            self.assertIn(
-                "proteins_url",
-                response.data,
-                "'proteins_url' should be one of the keys in the response",
+            self._check_details_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=self._check_match,
+                check_metadata_fn=self._check_entry_details,
+                check_subset_fn=lambda subset: self.assertEqual(
+                    len(subset), len(tests[url])
+                )
+                and self.assertEqual(
+                    tests[url].sort(), [x["accession"].upper() for x in subset].sort()
+                ),
             )
-            response = self.client.get(f"{url}?show-subset")
-            self.assertIn(
-                "protein_subset",
-                response.data,
-                "'proteins' should be one of the keys in the response",
-            )
-            self.assertEqual(len(response.data["protein_subset"]), len(tests[url]))
-            for match in response.data["protein_subset"]:
-                self._check_match(match)
-            ids = [x["accession"].upper() for x in response.data["protein_subset"]]
-            self.assertEqual(tests[url].sort(), ids.sort())
 
 
 class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):

--- a/webfront/tests/tests_entry_endpoint_structure_filter.py
+++ b/webfront/tests/tests_entry_endpoint_structure_filter.py
@@ -74,7 +74,7 @@ class EntryWithFilterStructurePDBRESTTest(InterproRESTTestCase):
         self._check_list_url_with_and_without_subset(
             "/api/entry/interpro/structure/pdb",
             "structure",
-            inner_subset_check_fn=self._check_entry_structure_details,
+            check_inner_subset_fn=self._check_entry_structure_details,
         )
 
     def test_can_get_structures_from_entry_acc_structure(self):
@@ -103,8 +103,8 @@ class EntryWithFilterStructurePDBRESTTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "structure",
-                inner_subset_check_fn=self._check_entry_structure_details,
-                subset_check_fn=check_subset,
+                check_inner_subset_fn=self._check_entry_structure_details,
+                check_subset_fn=check_subset,
             )
 
     def test_urls_that_should_fails_with_no_content(self):

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -160,17 +160,11 @@ class EntryTaxonomyTest(InterproRESTTestCase):
             f"/api/entry/interpro/{acc}/pfam/taxonomy/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "taxonomy",
+                inner_subset_check_fn=self._check_taxonomy_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "taxonomy_subset"
-            )
-            for result in response.data["results"]:
-                for taxon in result["taxonomy_subset"]:
-                    self._check_taxonomy_from_searcher(taxon)
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
         urls = [
@@ -180,12 +174,12 @@ class EntryTaxonomyTest(InterproRESTTestCase):
             "/api/entry/interpro/IPR003165/pfam/PF02171/taxonomy/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_entry_details(response.data["metadata"])
-            self.assertIn("taxonomy_subset", response.data)
-            for org in response.data["taxonomy_subset"]:
-                self._check_taxonomy_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "taxonomy",
+                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_metadata_fn=self._check_entry_details,
+            )
 
     def test_can_filter_entry_counter_with_taxonomy_acc(self):
         urls = ["/api/entry/taxonomy/uniprot/2579", "/api/entry/taxonomy/uniprot/40296"]
@@ -315,17 +309,11 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
             "/api/protein/uniprot/taxonomy/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "taxonomy",
+                inner_subset_check_fn=self._check_taxonomy_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "taxonomy_subset"
-            )
-            for result in response.data["results"]:
-                for org in result["taxonomy_subset"]:
-                    self._check_taxonomy_from_searcher(org)
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
         urls = [
@@ -334,12 +322,12 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
             "/api/protein/reviewed/A1CUJ5/taxonomy/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_protein_details(response.data["metadata"])
-            self.assertIn("taxonomy_subset", response.data)
-            for org in response.data["taxonomy_subset"]:
-                self._check_taxonomy_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "taxonomy",
+                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_metadata_fn=self._check_protein_details,
+            )
 
     def test_can_filter_counter_with_taxonomy_acc(self):
         urls = [
@@ -431,15 +419,11 @@ class StructureTaxonomyTest(InterproRESTTestCase):
 
     def test_can_get_the_taxonomy_list_on_a_list(self):
         url = "/api/structure/pdb/taxonomy/uniprot"
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-        self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self._check_is_list_of_objects_with_key(
-            response.data["results"], "taxonomy_subset"
+        self._check_list_url_with_and_without_subset(
+            url,
+            "taxonomy",
+            inner_subset_check_fn=self._check_taxonomy_from_searcher,
         )
-        for result in response.data["results"]:
-            for org in result["taxonomy_subset"]:
-                self._check_taxonomy_from_searcher(org)
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
         urls = [
@@ -447,12 +431,12 @@ class StructureTaxonomyTest(InterproRESTTestCase):
             "/api/structure/pdb/1JZ8/taxonomy/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_structure_details(response.data["metadata"])
-            self.assertIn("taxonomy_subset", response.data)
-            for org in response.data["taxonomy_subset"]:
-                self._check_taxonomy_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "taxonomy",
+                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_metadata_fn=self._check_structure_details,
+            )
 
     def test_can_filter_counter_with_taxonomy_acc(self):
         urls = [
@@ -579,12 +563,12 @@ class SetTaxonomyTest(InterproRESTTestCase):
             #            "/api/set/kegg/kegg01/node/KEGG01-1/taxonomy/uniprot/",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_set_details(response.data["metadata"], True)
-            self.assertIn("taxonomy_subset", response.data)
-            for st in response.data["taxonomy_subset"]:
-                self._check_taxonomy_from_searcher(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "taxonomy",
+                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_metadata_fn=self._check_set_details,
+            )
 
     def test_can_filter_set_counter_with_acc(self):
         urls = [

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -1146,34 +1146,25 @@ class TaxonomySetTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_list(self):
         urls = [
             "/api/taxonomy/uniprot/set/pfam",
-            #            "/api/taxonomy/uniprot/set/kegg",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "set_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["set_subset"]:
-                    self._check_set_from_searcher(s)
 
     def test_can_get_the_set_list_on_a__tax_object(self):
         urls = [
             "/api/taxonomy/uniprot/2579/set/pfam",
-            #            "/api/taxonomy/uniprot/2579/set/kegg",
-            #            "/api/taxonomy/uniprot/2579/set/kegg/kegg01/node",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_taxonomy_details(response.data["metadata"])
-            self.assertIn("set_subset", response.data)
-            for s in response.data["set_subset"]:
-                self._check_set_from_searcher(s)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
+                check_metadata_fn=self._check_taxonomy_details,
+            )
 
     def test_can_filter_counter_with_set_acc(self):
         urls = [

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -163,7 +163,7 @@ class EntryTaxonomyTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "taxonomy",
-                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_inner_subset_fn=self._check_taxonomy_from_searcher,
             )
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
@@ -177,7 +177,7 @@ class EntryTaxonomyTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "taxonomy",
-                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_inner_subset_fn=self._check_taxonomy_from_searcher,
                 check_metadata_fn=self._check_entry_details,
             )
 
@@ -312,7 +312,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "taxonomy",
-                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_inner_subset_fn=self._check_taxonomy_from_searcher,
             )
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
@@ -325,7 +325,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "taxonomy",
-                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_inner_subset_fn=self._check_taxonomy_from_searcher,
                 check_metadata_fn=self._check_protein_details,
             )
 
@@ -422,7 +422,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
         self._check_list_url_with_and_without_subset(
             url,
             "taxonomy",
-            inner_subset_check_fn=self._check_taxonomy_from_searcher,
+            check_inner_subset_fn=self._check_taxonomy_from_searcher,
         )
 
     def test_can_get_the_taxonomy_list_on_an_object(self):
@@ -434,7 +434,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "taxonomy",
-                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_inner_subset_fn=self._check_taxonomy_from_searcher,
                 check_metadata_fn=self._check_structure_details,
             )
 
@@ -566,7 +566,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "taxonomy",
-                inner_subset_check_fn=self._check_taxonomy_from_searcher,
+                check_inner_subset_fn=self._check_taxonomy_from_searcher,
                 check_metadata_fn=self._check_set_details,
             )
 
@@ -693,7 +693,7 @@ class TaxonomyEntryTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
                 check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
             )
 
@@ -708,7 +708,7 @@ class TaxonomyEntryTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
                 check_metadata_fn=self._check_taxonomy_details,
             )
 
@@ -841,26 +841,14 @@ class TaxonomyProteinTest(InterproRESTTestCase):
             "/api/taxonomy/uniprot/protein/reviewed",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=lambda p: self._check_match(
+                    p, include_coordinates=False
+                ),
+                check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
             )
-            for result in response.data["results"]:
-                self._check_taxonomy_details(result["metadata"], False)
-                self.assertIn(
-                    "proteins_url",
-                    result,
-                    f"Should have the field proteins_url in response",
-                )
-                self.assertURL(result["proteins_url"])
-            response = self.client.get(url + "?show-subset")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "protein_subset"
-            )
-            for result in response.data["results"]:
-                for st in result["protein_subset"]:
-                    self._check_match(st, include_coordinates=False)
 
     def test_can_get_a_list_from_the_taxonomy_object(self):
         urls = [
@@ -870,14 +858,14 @@ class TaxonomyProteinTest(InterproRESTTestCase):
             "/api/taxonomy/uniprot/344612/protein/reviewed",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_taxonomy_details(response.data["metadata"], False)
-            self.assertIn("proteins_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertIn("protein_subset", response.data)
-            for st in response.data["protein_subset"]:
-                self._check_match(st, include_coordinates=False)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=lambda p: self._check_match(
+                    p, include_coordinates=False
+                ),
+                check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
+            )
 
     def test_can_filter_taxonomy_counter_with_acc(self):
         urls = [
@@ -995,7 +983,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
             url,
             "structure",
             check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
-            inner_subset_check_fn=self._check_structure_chain_details,
+            check_inner_subset_fn=self._check_structure_chain_details,
         )
 
     def test_can_get_a_list_from_the_taxonomy_object(self):
@@ -1010,7 +998,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
                 url,
                 "structure",
                 check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
-                inner_subset_check_fn=self._check_structure_chain_details,
+                check_inner_subset_fn=self._check_structure_chain_details,
             )
 
     def test_can_filter_taxonomy_counter_with_acc(self):
@@ -1117,7 +1105,7 @@ class TaxonomySetTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
             )
 
     def test_can_get_the_set_list_on_a__tax_object(self):
@@ -1128,7 +1116,7 @@ class TaxonomySetTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
                 check_metadata_fn=self._check_taxonomy_details,
             )
 

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -773,6 +773,16 @@ class TaxonomyEntryTest(InterproRESTTestCase):
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
+                response.data["results"], "entries_url"
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
+            )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "metadata"
+            )
+            self._check_is_list_of_objects_with_key(
                 response.data["results"], "entry_subset"
             )
             for result in response.data["results"]:
@@ -789,6 +799,12 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
+            )
+            self._check_taxonomy_details(response.data["metadata"], False)
+            self.assertIn("entries_url", response.data)
+            response = self.client.get(url + "?show-subset")
             self.assertEqual(
                 response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
             )

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -65,10 +65,10 @@ class TaxonomyProteomeFixturesTest(InterproRESTTestCase):
         lineage = [1, 2, 40296]
         for taxon in lineage:
             response = self.client.get(
-                "/api/taxonomy/uniprot/{}/proteome/uniprot/UP000030104".format(taxon)
+                f"/api/taxonomy/uniprot/{taxon}/proteome/uniprot/UP000030104"
             )
             self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "failed at " + str(taxon)
+                response.status_code, status.HTTP_200_OK, f"failed at {str(taxon)}"
             )
             self.assertIn("proteomes", response.data)
             self.assertEqual(len(response.data["proteomes"]), 1)
@@ -91,13 +91,11 @@ class EntryTaxonomyTest(InterproRESTTestCase):
             "/api/entry/unintegrated/taxonomy/",
             "/api/entry/interpro/pfam/taxonomy/",
             "/api/entry/unintegrated/pfam/taxonomy/",
-            "/api/entry/interpro/" + acc + "/pfam/taxonomy",
+            f"/api/entry/interpro/{acc}/pfam/taxonomy",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -110,18 +108,16 @@ class EntryTaxonomyTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/entry/interpro/" + acc + "/taxonomy",
-            "/api/entry/pfam/" + pfam + "/taxonomy",
-            "/api/entry/pfam/" + pfam_un + "/taxonomy",
-            "/api/entry/interpro/" + acc + "/pfam/" + pfam + "/taxonomy",
-            "/api/entry/interpro/pfam/" + pfam + "/taxonomy",
-            "/api/entry/unintegrated/pfam/" + pfam_un + "/taxonomy",
+            f"/api/entry/interpro/{acc}/taxonomy",
+            f"/api/entry/pfam/{pfam}/taxonomy",
+            f"/api/entry/pfam/{pfam_un}/taxonomy",
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/taxonomy",
+            f"/api/entry/interpro/pfam/{pfam}/taxonomy",
+            f"/api/entry/unintegrated/pfam/{pfam_un}/taxonomy",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn(
                 "taxa",
@@ -133,9 +129,7 @@ class EntryTaxonomyTest(InterproRESTTestCase):
     def test_can_filter_entry_counter_with_taxonomy_db(self):
         url = "/api/entry/taxonomy/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(
             "taxa",
             response.data["entries"]["integrated"],
@@ -153,13 +147,11 @@ class EntryTaxonomyTest(InterproRESTTestCase):
         urls = [
             "/api/entry/interpro/taxonomy/uniprot",
             "/api/entry/unintegrated/taxonomy/uniprot",
-            "/api/entry/interpro/" + acc + "/pfam/taxonomy/uniprot",
+            f"/api/entry/interpro/{acc}/pfam/taxonomy/uniprot",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -179,9 +171,7 @@ class EntryTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn("taxonomy_subset", response.data)
             for org in response.data["taxonomy_subset"]:
@@ -191,9 +181,7 @@ class EntryTaxonomyTest(InterproRESTTestCase):
         urls = ["/api/entry/taxonomy/uniprot/2579", "/api/entry/taxonomy/uniprot/40296"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_count_overview(response.data)
 
     def test_can_get_the_taxonomy_object_on_a_list(self):
@@ -202,13 +190,11 @@ class EntryTaxonomyTest(InterproRESTTestCase):
             "/api/entry/interpro/taxonomy/uniprot/2579",
             "/api/entry/unintegrated/taxonomy/uniprot/2579",
             "/api/entry/unintegrated/taxonomy/uniprot/344612",
-            "/api/entry/interpro/" + acc + "/pfam/taxonomy/uniprot/344612",
+            f"/api/entry/interpro/{acc}/pfam/taxonomy/uniprot/344612",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -225,9 +211,7 @@ class EntryTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn("taxa", response.data)
             for org in response.data["taxa"]:
@@ -249,9 +233,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -263,16 +245,14 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         reviewed = "A1CUJ5"
         unreviewed = "P16582"
         urls = [
-            "/api/protein/uniprot/" + reviewed + "/taxonomy/",
-            "/api/protein/uniprot/" + unreviewed + "/taxonomy/",
-            "/api/protein/reviewed/" + reviewed + "/taxonomy/",
-            "/api/protein/unreviewed/" + unreviewed + "/taxonomy/",
+            f"/api/protein/uniprot/{reviewed}/taxonomy/",
+            f"/api/protein/uniprot/{unreviewed}/taxonomy/",
+            f"/api/protein/reviewed/{reviewed}/taxonomy/",
+            f"/api/protein/unreviewed/{unreviewed}/taxonomy/",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn(
                 "taxa",
@@ -284,9 +264,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
     def test_can_filter_protein_counter_with_taxonomy_db(self):
         url = "/api/protein/taxonomy/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(
             "proteins",
             response.data["proteins"]["uniprot"],
@@ -328,9 +306,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -349,9 +325,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn("taxonomy_subset", response.data)
             for org in response.data["taxonomy_subset"]:
@@ -364,9 +338,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_count_overview(response.data)
 
     def test_can_get_the_taxonomy_object_on_a_list(self):
@@ -376,9 +348,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -396,9 +366,7 @@ class ProteinTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn("taxa", response.data)
             for org in response.data["taxa"]:
@@ -415,9 +383,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
     def test_can_get_the_taxonomy_count_on_a_list(self):
         url = "/api/structure/pdb/taxonomy/"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "taxa")
         for result in response.data["results"]:
@@ -425,14 +391,11 @@ class StructureTaxonomyTest(InterproRESTTestCase):
 
     def test_urls_that_return_structure_with_taxonomy_count(self):
         urls = [
-            "/api/structure/pdb/" + pdb + "/taxonomy/"
-            for pdb in ["1JM7", "2BKM", "1T2V"]
+            f"/api/structure/pdb/{pdb}/taxonomy/" for pdb in ["1JM7", "2BKM", "1T2V"]
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn(
                 "taxa",
@@ -444,9 +407,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
     def test_can_filter_structure_counter_with_taxonomy_db(self):
         url = "/api/structure/taxonomy/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(
             "structures",
             response.data["structures"]["pdb"],
@@ -461,9 +422,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
     def test_can_get_the_taxonomy_list_on_a_list(self):
         url = "/api/structure/pdb/taxonomy/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(
             response.data["results"], "taxonomy_subset"
@@ -479,9 +438,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn("taxonomy_subset", response.data)
             for org in response.data["taxonomy_subset"]:
@@ -494,9 +451,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_count_overview(response.data)
 
     def test_can_get_the_taxonomy_object_on_a_list(self):
@@ -506,9 +461,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -525,9 +478,7 @@ class StructureTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn("taxa", response.data)
             for org in response.data["taxa"]:
@@ -549,9 +500,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -567,9 +516,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn(
                 "taxa",
@@ -581,9 +528,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
     def test_can_filter_set_counter_with_structure_db(self):
         url = "/api/set/taxonomy/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIsInstance(response.data, dict)
         # if "kegg" in response.data["sets"]:
         #     self.assertIn("taxa", response.data["sets"]["kegg"],
@@ -609,9 +554,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -627,9 +570,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
             self.assertIn("taxonomy_subset", response.data)
             for st in response.data["taxonomy_subset"]:
@@ -644,9 +585,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_count_overview(response.data)
 
     #     def test_can_get_object_on_a_set_list(self):
@@ -673,9 +612,7 @@ class SetTaxonomyTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn("taxa", response.data)
             for s in response.data["taxa"]:
@@ -692,9 +629,7 @@ class TaxonomyEntryTest(InterproRESTTestCase):
     def test_can_get_the_entry_count_on_a_list(self):
         url = "/api/taxonomy/uniprot/entry"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "entries")
         for result in response.data["results"]:
@@ -713,9 +648,7 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         urls = ["/api/taxonomy/uniprot/40296/entry", "/api/taxonomy/uniprot/2/entry"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"])
             self.assertIn(
                 "entries",
@@ -732,13 +665,11 @@ class TaxonomyEntryTest(InterproRESTTestCase):
             "/api/taxonomy/entry/unintegrated",
             "/api/taxonomy/entry/unintegrated/pfam",
             "/api/taxonomy/entry/interpro/pfam",
-            "/api/taxonomy/entry/interpro/" + acc + "/pfam",
+            f"/api/taxonomy/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             self.assertIn(
                 "uniprot",
@@ -766,19 +697,15 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "entries_url"
             )
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            response = self.client.get(f"{url}?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -799,15 +726,11 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
             self.assertIn("entries_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            response = self.client.get(f"{url}?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
             self.assertIn("entry_subset", response.data)
             for st in response.data["entry_subset"]:
@@ -818,18 +741,16 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/taxonomy/entry/interpro/" + acc,
-            "/api/taxonomy/entry/pfam/" + pfam,
-            "/api/taxonomy/entry/pfam/" + pfam_un,
-            "/api/taxonomy/entry/interpro/" + acc + "/pfam/" + pfam,
-            "/api/taxonomy/entry/interpro/pfam/" + pfam,
-            "/api/taxonomy/entry/unintegrated/pfam/" + pfam_un,
+            f"/api/taxonomy/entry/interpro/{acc}",
+            f"/api/taxonomy/entry/pfam/{pfam}",
+            f"/api/taxonomy/entry/pfam/{pfam_un}",
+            f"/api/taxonomy/entry/interpro/{acc}/pfam/{pfam}",
+            f"/api/taxonomy/entry/interpro/pfam/{pfam}",
+            f"/api/taxonomy/entry/unintegrated/pfam/{pfam_un}",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_count_overview(response.data)
 
     def test_can_get_object_on_a_taxonomy_list(self):
@@ -837,16 +758,14 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/taxonomy/uniprot/entry/interpro/" + acc,
-            "/api/taxonomy/uniprot/entry/unintegrated/pfam/" + pfam_un,
-            "/api/taxonomy/uniprot/entry/interpro/pfam/" + pfam,
-            "/api/taxonomy/uniprot/entry/interpro/IPR003165/pfam/" + pfam,
+            f"/api/taxonomy/uniprot/entry/interpro/{acc}",
+            f"/api/taxonomy/uniprot/entry/unintegrated/pfam/{pfam_un}",
+            f"/api/taxonomy/uniprot/entry/interpro/pfam/{pfam}",
+            f"/api/taxonomy/uniprot/entry/interpro/IPR003165/pfam/{pfam}",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -865,9 +784,7 @@ class TaxonomyEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
             self.assertIn("entries", response.data)
             for st in response.data["entries"]:
@@ -884,9 +801,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
     def test_can_get_the_protein_count_on_a_list(self):
         url = "/api/taxonomy/uniprot/protein"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "proteins")
         for result in response.data["results"]:
@@ -908,9 +823,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"])
             self.assertIn(
                 "proteins",
@@ -927,9 +840,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             self.assertIn(
                 "uniprot",
@@ -955,17 +866,23 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
+            for result in response.data["results"]:
+                self._check_taxonomy_details(result["metadata"], False)
+                self.assertIn(
+                    "proteins_url",
+                    result,
+                    f"Should have the field proteins_url in response",
+                )
+                self.asserURL(result["proteins_url"])
+            response = self.client.get(url + "?show-subset")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "protein_subset"
             )
             for result in response.data["results"]:
-                self._check_taxonomy_details(result["metadata"], False)
                 for st in result["protein_subset"]:
                     self._check_match(st, include_coordinates=False)
 
@@ -978,10 +895,10 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
+            self.assertIn("proteins_url", response.data)
+            response = self.client.get(url + "?show-subset")
             self.assertIn("protein_subset", response.data)
             for st in response.data["protein_subset"]:
                 self._check_match(st, include_coordinates=False)
@@ -994,9 +911,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_count_overview(response.data)
 
     def test_can_get_object_on_a_taxonomy_list(self):
@@ -1008,9 +923,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1031,9 +944,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
             self.assertIn("proteins", response.data)
             for st in response.data["proteins"]:
@@ -1050,9 +961,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
     def test_can_get_the_protein_count_on_a_list(self):
         url = "/api/taxonomy/uniprot/structure"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "structures")
         for result in response.data["results"]:
@@ -1074,9 +983,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"])
             self.assertIn(
                 "structures",
@@ -1088,9 +995,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
     def test_can_filter_structure_counter_with_taxonomy_db(self):
         url = "/api/taxonomy/structure/pdb"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIsInstance(response.data, dict)
         self.assertIn(
             "uniprot",
@@ -1111,9 +1016,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
     def test_can_get_a_list_from_the_taxonomy_list(self):
         url = "/api/taxonomy/uniprot/structure/pdb"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(
             response.data["results"], "structure_subset"
@@ -1132,9 +1035,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
             self.assertIn("structure_subset", response.data)
             for st in response.data["structure_subset"]:
@@ -1144,9 +1045,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
         urls = ["/api/taxonomy/structure/pdb/1JM7", "/api/taxonomy/structure/pdb/1JZ8"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_count_overview(response.data)
 
     def test_can_get_object_on_a_taxonomy_list(self):
@@ -1156,9 +1055,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1179,9 +1076,7 @@ class TaxonomyStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"], False)
             self.assertIn("structures", response.data)
             for st in response.data["structures"]:
@@ -1198,9 +1093,7 @@ class TaxonomySetTest(InterproRESTTestCase):
     def test_can_get_the_set_count_on_a_list(self):
         url = "/api/taxonomy/uniprot/set"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "sets")
         for result in response.data["results"]:
@@ -1210,9 +1103,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         urls = ["/api/taxonomy/uniprot/1001583/set", "/api/taxonomy/uniprot/1/set"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"])
             self.assertIn(
                 "sets",
@@ -1229,9 +1120,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn(
                 "uniprot",
                 response.data["taxa"],
@@ -1255,9 +1144,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1276,9 +1163,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"])
             self.assertIn("set_subset", response.data)
             for s in response.data["set_subset"]:
@@ -1293,9 +1178,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
@@ -1306,9 +1189,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1326,9 +1207,7 @@ class TaxonomySetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_taxonomy_details(response.data["metadata"])
             self.assertIn("sets", response.data)
             for s in response.data["sets"]:

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -887,7 +887,7 @@ class TaxonomyProteinTest(InterproRESTTestCase):
                     result,
                     f"Should have the field proteins_url in response",
                 )
-                self.asserURL(result["proteins_url"])
+                self.assertURL(result["proteins_url"])
             response = self.client.get(url + "?show-subset")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "protein_subset"
@@ -1025,16 +1025,12 @@ class TaxonomyStructureTest(InterproRESTTestCase):
 
     def test_can_get_a_list_from_the_taxonomy_list(self):
         url = "/api/taxonomy/uniprot/structure/pdb"
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-        self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self._check_is_list_of_objects_with_key(
-            response.data["results"], "structure_subset"
+        self._check_list_url_with_and_without_subset(
+            url,
+            "structure",
+            check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
+            inner_subset_check_fn=self._check_structure_chain_details,
         )
-        for result in response.data["results"]:
-            self._check_taxonomy_details(result["metadata"], False)
-            for st in result["structure_subset"]:
-                self._check_structure_chain_details(st)
 
     def test_can_get_a_list_from_the_taxonomy_object(self):
         urls = [
@@ -1044,12 +1040,12 @@ class TaxonomyStructureTest(InterproRESTTestCase):
             "/api/taxonomy/uniprot/344612/structure/pdb",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_taxonomy_details(response.data["metadata"], False)
-            self.assertIn("structure_subset", response.data)
-            for st in response.data["structure_subset"]:
-                self._check_structure_chain_details(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "structure",
+                check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
+                inner_subset_check_fn=self._check_structure_chain_details,
+            )
 
     def test_can_filter_taxonomy_counter_with_acc(self):
         urls = ["/api/taxonomy/structure/pdb/1JM7", "/api/taxonomy/structure/pdb/1JZ8"]

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -48,28 +48,22 @@ class TaxonomyProteomeFixturesTest(InterproRESTTestCase):
         self.assertEqual(response.data["proteomes"]["uniprot"], 1)
 
     def test_can_read_taxonomy_leaf_id_with_proteomes(self):
-        response = self.client.get("/api/taxonomy/uniprot/40296/proteome/uniprot")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("metadata", response.data)
-        self.assertIn("proteomes_url", response.data)
-        response = self.client.get(
-            "/api/taxonomy/uniprot/40296/proteome/uniprot?show-subset"
+        url = "/api/taxonomy/uniprot/40296/proteome/uniprot"
+        self._check_details_url_with_and_without_subset(
+            url,
+            "proteome",
+            check_metadata_fn=self._check_taxonomy_details,
+            check_subset_fn=lambda s: self.assertEqual(len(s), 1),
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("proteome_subset", response.data)
-        self.assertEqual(len(response.data["proteome_subset"]), 1)
 
     def test_can_read_taxonomy_node_id_with_proteomes(self):
-        response = self.client.get("/api/taxonomy/uniprot/2579/proteome/uniprot")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("metadata", response.data)
-        self.assertIn("proteomes_url", response.data)
-        response = self.client.get(
-            "/api/taxonomy/uniprot/2579/proteome/uniprot?show-subset"
+        url = "/api/taxonomy/uniprot/2579/proteome/uniprot"
+        self._check_details_url_with_and_without_subset(
+            url,
+            "proteome",
+            check_metadata_fn=self._check_taxonomy_details,
+            check_subset_fn=lambda s: self.assertEqual(len(s), 3),
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("proteome_subset", response.data)
-        self.assertEqual(len(response.data["proteome_subset"]), 3)
 
     def test_can_read_proteome_id_including_tax_id(self):
         lineage = [1, 2, 40296]

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -690,26 +690,12 @@ class TaxonomyEntryTest(InterproRESTTestCase):
             "/api/taxonomy/uniprot/entry/interpro/IPR003165/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "entry",
+                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_metadata_fn=lambda m: self._check_taxonomy_details(m, False),
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "entries_url"
-            )
-            response = self.client.get(f"{url}?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
-            )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "entry_subset"
-            )
-            for result in response.data["results"]:
-                self._check_taxonomy_details(result["metadata"], False)
-                for st in result["entry_subset"]:
-                    self._check_entry_from_searcher(st)
 
     def test_can_get_a_list_from_the_taxonomy_object(self):
         urls = [
@@ -719,16 +705,12 @@ class TaxonomyEntryTest(InterproRESTTestCase):
             "/api/taxonomy/uniprot/344612/entry/unintegrated/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_taxonomy_details(response.data["metadata"], False)
-            self.assertIn("entries_url", response.data)
-            response = self.client.get(f"{url}?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_taxonomy_details(response.data["metadata"], False)
-            self.assertIn("entry_subset", response.data)
-            for st in response.data["entry_subset"]:
-                self._check_entry_from_searcher(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "entry",
+                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_metadata_fn=self._check_taxonomy_details,
+            )
 
     def test_can_filter_taxonomy_counter_with_acc(self):
         acc = "IPR003165"

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -51,6 +51,11 @@ class TaxonomyProteomeFixturesTest(InterproRESTTestCase):
         response = self.client.get("/api/taxonomy/uniprot/40296/proteome/uniprot")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("metadata", response.data)
+        self.assertIn("proteomes_url", response.data)
+        response = self.client.get(
+            "/api/taxonomy/uniprot/40296/proteome/uniprot?show-subset"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("proteome_subset", response.data)
         self.assertEqual(len(response.data["proteome_subset"]), 1)
 
@@ -58,6 +63,11 @@ class TaxonomyProteomeFixturesTest(InterproRESTTestCase):
         response = self.client.get("/api/taxonomy/uniprot/2579/proteome/uniprot")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("metadata", response.data)
+        self.assertIn("proteomes_url", response.data)
+        response = self.client.get(
+            "/api/taxonomy/uniprot/2579/proteome/uniprot?show-subset"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("proteome_subset", response.data)
         self.assertEqual(len(response.data["proteome_subset"]), 3)
 

--- a/webfront/tests/tests_organism.py
+++ b/webfront/tests/tests_organism.py
@@ -483,8 +483,6 @@ class SetTaxonomyTest(InterproRESTTestCase):
     def test_can_get_the_taxonomy_count_on_a_list(self):
         urls = [
             "/api/set/pfam/taxonomy",
-            #            "/api/set/kegg/taxonomy",
-            #            "/api/set/kegg/KEGG01/node/taxonomy",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -499,8 +497,6 @@ class SetTaxonomyTest(InterproRESTTestCase):
     def test_can_get_the_taxonomy_count_on_a_set(self):
         urls = [
             "/api/set/pfam/CL0001/taxonomy",
-            #            "/api/set/kegg/KEGG01/taxonomy",
-            #            "/api/set/kegg/KEGG01/node/KEGG01-1/taxonomy",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -518,11 +514,6 @@ class SetTaxonomyTest(InterproRESTTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIsInstance(response.data, dict)
-        # if "kegg" in response.data["sets"]:
-        #     self.assertIn("taxa", response.data["sets"]["kegg"],
-        #                   "'taxa' should be one of the keys in the response")
-        #     self.assertIn("sets", response.data["sets"]["kegg"],
-        #                   "'sets' should be one of the keys in the response")
         if "pfam" in response.data["sets"]:
             self.assertIn(
                 "taxa",
@@ -535,26 +526,9 @@ class SetTaxonomyTest(InterproRESTTestCase):
                 "'sets' should be one of the keys in the response",
             )
 
-    def test_can_get_the_set_list_on_a_list(self):
-        urls = [
-            #            "/api/set/kegg/taxonomy/uniprot",
-            #            "/api/set/kegg/kegg01/node/taxonomy/uniprot",
-        ]
-        for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
-            )
-            self._check_is_list_of_objects_with_key(response.data["results"], "taxa")
-            for result in response.data["results"]:
-                for s in result["taxa"]:
-                    self._check_taxonomy_from_searcher(s)
-
     def test_can_get_a_list_from_the_set_object(self):
         urls = [
             "/api/set/pfam/Cl0001/taxonomy/uniprot",
-            #            "/api/set/kegg/kegg01/node/KEGG01-1/taxonomy/uniprot/",
         ]
         for url in urls:
             self._check_details_url_with_and_without_subset(
@@ -576,28 +550,8 @@ class SetTaxonomyTest(InterproRESTTestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_count_overview(response.data)
 
-    #     def test_can_get_object_on_a_set_list(self):
-    #         urls = [
-    # #            "/api/set/kegg/taxonomy/uniprot/2579",
-    # #            "/api/set/kegg/taxonomy/uniprot/344612",
-    #             ]
-    #         for url in urls:
-    #             response = self.client.get(url)
-    #             self.assertEqual(response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url))
-    #             self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-    #             self._check_is_list_of_objects_with_key(response.data["results"], "taxa")
-    #             for result in response.data["results"]:
-    #                 self._check_set_details(result["metadata"], False)
-    #                 for st in result["taxa"]:
-    #                     self._check_taxonomy_from_searcher(st)
-
     def test_can_get_an_object_from_the_set_object(self):
-        urls = [
-            #            "/api/set/kegg/kegg01/taxonomy/uniprot/2",
-            #            "/api/set/kegg/kegg01/taxonomy/uniprot/40296",
-            #            "/api/set/kegg/kegg01/node/kegg01-1/taxonomy/uniprot/40296",
-            "/api/set/pfam/Cl0001/taxonomy/uniprot/344612"
-        ]
+        urls = ["/api/set/pfam/Cl0001/taxonomy/uniprot/344612"]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
@@ -1069,8 +1023,6 @@ class TaxonomySetTest(InterproRESTTestCase):
     def test_can_filter_taxonomy_counter_with_taxonomy_db(self):
         urls = [
             "/api/taxonomy/set/pfam",
-            #            "/api/taxonomy/set/kegg",
-            #            "/api/taxonomy/set/kegg/kegg01/node",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -1117,9 +1069,6 @@ class TaxonomySetTest(InterproRESTTestCase):
     def test_can_filter_counter_with_set_acc(self):
         urls = [
             "/api/taxonomy/set/pfam/Cl0001",
-            #            "/api/taxonomy/set/kegg/kegg01",
-            #            "/api/taxonomy/set/kegg/kegg01/node/KEGG01-1",
-            #            "/api/taxonomy/set/kegg/kegg01/node/KEGG01-2",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -1127,11 +1076,7 @@ class TaxonomySetTest(InterproRESTTestCase):
             self._check_taxonomy_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
-        urls = [
-            #            "/api/taxonomy/uniprot/set/kegg/kegg01",
-            #            "/api/taxonomy/uniprot/set/kegg/kegg01/node/kegg01-1",
-            "/api/taxonomy/uniprot/set/pfam/Cl0001"
-        ]
+        urls = ["/api/taxonomy/uniprot/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
@@ -1144,12 +1089,7 @@ class TaxonomySetTest(InterproRESTTestCase):
                     self._check_set_from_searcher(org)
 
     def test_can_get_the_object_on_an_object(self):
-        urls = [
-            #            "/api/taxonomy/uniprot/2/set/kegg/kegg01",
-            #            "/api/taxonomy/uniprot/40296/set/kegg/kegg01",
-            #            "/api/taxonomy/uniprot/40296/set/kegg/kegg01/node/kegg01-1",
-            "/api/taxonomy/uniprot/344612/set/pfam/Cl0001"
-        ]
+        urls = ["/api/taxonomy/uniprot/344612/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")

--- a/webfront/tests/tests_protein_endpoint_entry_filter.py
+++ b/webfront/tests/tests_protein_endpoint_entry_filter.py
@@ -119,7 +119,7 @@ class ProteinWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_match,
+                check_inner_subset_fn=self._check_match,
             )
 
     def test_urls_that_return_a_protein_details_with_matches(self):
@@ -140,9 +140,9 @@ class ProteinWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
                 check_metadata_fn=self._check_protein_details,
-                subset_check_fn=lambda subset: self.assertEqual(
+                check_subset_fn=lambda subset: self.assertEqual(
                     len(subset),
                     len(urls[url]),
                     "The number of entries should be the same URL: [{}]".format(url),

--- a/webfront/tests/tests_protein_endpoint_entry_filter.py
+++ b/webfront/tests/tests_protein_endpoint_entry_filter.py
@@ -123,6 +123,16 @@ class ProteinWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             )
             self._check_is_list_of_objects_with_key(
                 response.data["results"],
+                "entries_url",
+                "It should have the key 'entries_url' for the URL [" + url + "]",
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "metadata"
+            )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"],
                 "entry_subset",
                 "It should have the key 'entry_subset' for the URL [" + url + "]",
             )
@@ -135,29 +145,24 @@ class ProteinWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
         sp_2 = "A1CUJ5"
         acc = "IPR003165"
         urls = {
-            "/api/protein/uniprot/"
-            + sp_2
-            + "/entry/interpro": ["IPR003165", "IPR001165"],
-            "/api/protein/uniprot/"
-            + sp_1
-            + "/entry/unintegrated": ["PF17180", "PTHR43214"],
-            "/api/protein/uniprot/" + sp_2 + "/entry/pfam": ["PF17176", "PF02171"],
-            "/api/protein/uniprot/" + sp_2 + "/entry/interpro/pfam": ["PF02171"],
-            "/api/protein/uniprot/" + sp_2 + "/entry/interpro/smart": ["SM00950"],
-            "/api/protein/uniprot/" + sp_1 + "/entry/unintegrated/pfam": ["PF17180"],
-            "/api/protein/uniprot/"
-            + sp_2
-            + "/entry/interpro/"
-            + acc
-            + "/smart": ["SM00950"],
-            "/api/protein/uniprot/"
-            + sp_2
-            + "/entry/interpro/"
-            + acc
-            + "/pfam": ["PF02171"],
+            f"/api/protein/uniprot/{sp_2}/entry/interpro": ["IPR003165", "IPR001165"],
+            f"/api/protein/uniprot/{sp_1}/entry/unintegrated": ["PF17180", "PTHR43214"],
+            f"/api/protein/uniprot/{sp_2}/entry/pfam": ["PF17176", "PF02171"],
+            f"/api/protein/uniprot/{sp_2}/entry/interpro/pfam": ["PF02171"],
+            f"/api/protein/uniprot/{sp_2}/entry/interpro/smart": ["SM00950"],
+            f"/api/protein/uniprot/{sp_1}/entry/unintegrated/pfam": ["PF17180"],
+            f"/api/protein/uniprot/{sp_2}/entry/interpro/{acc}/smart": ["SM00950"],
+            f"/api/protein/uniprot/{sp_2}/entry/interpro/{acc}/pfam": ["PF02171"],
         }
         for url in urls:
             response = self.client.get(url)
+            self._check_protein_details(response.data["metadata"])
+            self.assertIn(
+                "entries_url",
+                response.data,
+                "'entries_url' should be one of the keys in the response",
+            )
+            response = self.client.get(url + "?show-subset")
             self._check_protein_details(response.data["metadata"])
             self.assertIn(
                 "entry_subset",
@@ -204,7 +209,7 @@ class ProteinWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
         tests = [
             "/api/protein/entry/unintegrated/smart",
             "/api/protein/uniprot/entry/unintegrated/smart",
-            "/api/protein/uniprot/" + tr_1 + "/entry/unintegrated",
+            f"/api/protein/uniprot/{tr_1}/entry/unintegrated",
         ]
         for url in tests:
             self._check_HTTP_response_code(

--- a/webfront/tests/tests_protein_endpoint_structure_filter.py
+++ b/webfront/tests/tests_protein_endpoint_structure_filter.py
@@ -73,37 +73,37 @@ class ProteinWithFilterStructurePdbRESTTest(InterproRESTTestCase):
         )
 
     def test_can_get_proteins_from_pdb_structures(self):
-        response = self.client.get("/api/protein/uniprot/structure/pdb")
-        self.assertEqual(len(response.data["results"]), len(data_in_fixtures))
-        for result in response.data["results"]:
-            self.assertEqual(
+        self._check_list_url_with_and_without_subset(
+            "/api/protein/uniprot/structure/pdb",
+            "structure",
+            check_results_fn=lambda results: self.assertEqual(
+                len(results), len(data_in_fixtures)
+            ),
+            check_result_fn=lambda result: self.assertEqual(
                 len(result["structure_subset"]),
                 len(data_in_fixtures[result["metadata"]["accession"]]),
                 "failing for " + result["metadata"]["accession"],
-            )
-            for match in result["structure_subset"]:
-                self.assertIn(
-                    match["accession"].lower(),
-                    data_in_fixtures[result["metadata"]["accession"]],
-                )
-                self._check_structure_chain_details(match)
+            ),
+            inner_subset_check_fn=self._check_structure_chain_details,
+        )
 
     def test_can_get_reviewed_from_pdb_structures(self):
-        response = self.client.get("/api/protein/reviewed/structure/pdb")
-        self.assertEqual(len(response.data["results"]), len(data_reviewed))
-        for result in response.data["results"]:
-            self.assertEqual(
+        self._check_list_url_with_and_without_subset(
+            "/api/protein/reviewed/structure/pdb",
+            "structure",
+            check_results_fn=lambda results: self.assertEqual(
+                len(results), len(data_reviewed)
+            ),
+            check_result_fn=lambda result: self.assertEqual(
                 len(result["structure_subset"]),
                 len(data_in_fixtures[result["metadata"]["accession"]]),
                 "failing for " + result["metadata"]["accession"],
-            )
-            self.assertIn(result["metadata"]["accession"], data_reviewed)
-            for match in result["structure_subset"]:
-                self.assertIn(
-                    match["accession"].lower(),
-                    data_in_fixtures[result["metadata"]["accession"]],
-                )
-                self._check_structure_chain_details(match)
+            ),
+            check_metadata_fn=lambda metadata: self.assertIn(
+                metadata["accession"], data_reviewed
+            ),
+            inner_subset_check_fn=self._check_structure_chain_details,
+        )
 
     def test_can_get_uniprot_matches_from_structures(self):
         tests = {
@@ -111,17 +111,17 @@ class ProteinWithFilterStructurePdbRESTTest(InterproRESTTestCase):
             for prot in data_in_fixtures
         }
         for url in tests:
-            response = self.client.get(url)
-            self.assertIn(
-                "structure_subset",
-                response.data,
-                "'structure_subset' should be one of the keys in the response",
+            self._check_details_url_with_and_without_subset(
+                url,
+                "structure",
+                subset_check_fn=lambda subset: self.assertEqual(
+                    len(subset), len(tests[url])
+                )
+                and self.assertEqual(
+                    tests[url].sort(), [x["accession"] for x in subset].sort()
+                ),
+                inner_subset_check_fn=self._check_structure_chain_details,
             )
-            self.assertEqual(len(response.data["structure_subset"]), len(tests[url]))
-            for match in response.data["structure_subset"]:
-                self._check_structure_chain_details(match)
-            ids = [x["accession"] for x in response.data["structure_subset"]]
-            self.assertEqual(tests[url].sort(), ids.sort())
 
     def test_urls_that_should_fails(self):
         prot_s = "M5ADK6"

--- a/webfront/tests/tests_protein_endpoint_structure_filter.py
+++ b/webfront/tests/tests_protein_endpoint_structure_filter.py
@@ -84,7 +84,7 @@ class ProteinWithFilterStructurePdbRESTTest(InterproRESTTestCase):
                 len(data_in_fixtures[result["metadata"]["accession"]]),
                 "failing for " + result["metadata"]["accession"],
             ),
-            inner_subset_check_fn=self._check_structure_chain_details,
+            check_inner_subset_fn=self._check_structure_chain_details,
         )
 
     def test_can_get_reviewed_from_pdb_structures(self):
@@ -102,7 +102,7 @@ class ProteinWithFilterStructurePdbRESTTest(InterproRESTTestCase):
             check_metadata_fn=lambda metadata: self.assertIn(
                 metadata["accession"], data_reviewed
             ),
-            inner_subset_check_fn=self._check_structure_chain_details,
+            check_inner_subset_fn=self._check_structure_chain_details,
         )
 
     def test_can_get_uniprot_matches_from_structures(self):
@@ -114,13 +114,13 @@ class ProteinWithFilterStructurePdbRESTTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "structure",
-                subset_check_fn=lambda subset: self.assertEqual(
+                check_subset_fn=lambda subset: self.assertEqual(
                     len(subset), len(tests[url])
                 )
                 and self.assertEqual(
                     tests[url].sort(), [x["accession"] for x in subset].sort()
                 ),
-                inner_subset_check_fn=self._check_structure_chain_details,
+                check_inner_subset_fn=self._check_structure_chain_details,
             )
 
     def test_urls_that_should_fails(self):

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -777,6 +777,16 @@ class ProteomeEntryTest(InterproRESTTestCase):
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
+                response.data["results"], "entries_url"
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
+            )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "metadata"
+            )
+            self._check_is_list_of_objects_with_key(
                 response.data["results"], "entry_subset"
             )
             for result in response.data["results"]:
@@ -794,6 +804,12 @@ class ProteomeEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
+            )
+            self._check_proteome_details(response.data["metadata"], False)
+            self.assertIn("entries_url", response.data)
+            response = self.client.get(url + "?show-subset")
             self.assertEqual(
                 response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
             )

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -728,7 +728,7 @@ class ProteomeEntryTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
                 check_metadata_fn=lambda metadata: self._check_proteome_details(
                     metadata, False
                 ),
@@ -746,7 +746,7 @@ class ProteomeEntryTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
                 check_metadata_fn=self._check_proteome_details,
             )
 
@@ -875,22 +875,14 @@ class ProteomeProteinTest(InterproRESTTestCase):
             "/api/proteome/uniprot/protein/reviewed",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=lambda p: self._check_match(
+                    p, include_coordinates=False
+                ),
+                check_metadata_fn=lambda m: self._check_proteome_details(m, False),
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteins_url"
-            )
-            response = self.client.get(url + "?show-subset")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "protein_subset"
-            )
-            for result in response.data["results"]:
-                self._check_proteome_details(result["metadata"], False)
-                for st in result["protein_subset"]:
-                    self._check_match(st, include_coordinates=False)
 
     def test_can_get_a_list_from_the_proteome_object(self):
         urls = [
@@ -899,14 +891,14 @@ class ProteomeProteinTest(InterproRESTTestCase):
             "/api/proteome/uniprot/UP000006701/protein/reviewed",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_proteome_details(response.data["metadata"], False)
-            self.assertIn("proteins_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertIn("protein_subset", response.data)
-            for st in response.data["protein_subset"]:
-                self._check_match(st, include_coordinates=False)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "protein",
+                check_inner_subset_fn=lambda p: self._check_match(
+                    p, include_coordinates=False
+                ),
+                check_metadata_fn=lambda m: self._check_proteome_details(m, False),
+            )
 
     def test_can_filter_proteome_counter_with_acc(self):
         urls = [
@@ -1031,7 +1023,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
             url,
             "structure",
             check_metadata_fn=lambda m: self._check_proteome_details(m, False),
-            inner_subset_check_fn=self._check_structure_chain_details,
+            check_inner_subset_fn=self._check_structure_chain_details,
         )
 
     def test_can_get_a_list_from_the_proteome_object(self):
@@ -1044,7 +1036,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
                 url,
                 "structure",
                 check_metadata_fn=lambda m: self._check_proteome_details(m, False),
-                inner_subset_check_fn=self._check_structure_chain_details,
+                check_inner_subset_fn=self._check_structure_chain_details,
             )
 
     def test_can_filter_proteome_counter_with_acc(self):
@@ -1152,7 +1144,7 @@ class ProteomeSetTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
             )
 
     def test_can_get_the_set_list_on_a_proteome_object(self):
@@ -1165,7 +1157,7 @@ class ProteomeSetTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "set",
-                inner_subset_check_fn=self._check_set_from_searcher,
+                check_inner_subset_fn=self._check_set_from_searcher,
                 check_metadata_fn=self._check_proteome_details,
             )
 

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -78,13 +78,11 @@ class EntryProteomeTest(InterproRESTTestCase):
             "/api/entry/unintegrated/proteome/",
             "/api/entry/interpro/pfam/proteome/",
             "/api/entry/unintegrated/pfam/proteome/",
-            "/api/entry/interpro/" + acc + "/pfam/proteome",
+            f"/api/entry/interpro/{acc}/pfam/proteome",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -99,18 +97,16 @@ class EntryProteomeTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/entry/interpro/" + acc + "/proteome",
-            "/api/entry/pfam/" + pfam + "/proteome",
-            "/api/entry/pfam/" + pfam_un + "/proteome",
-            "/api/entry/interpro/" + acc + "/pfam/" + pfam + "/proteome",
-            "/api/entry/interpro/pfam/" + pfam + "/proteome",
-            "/api/entry/unintegrated/pfam/" + pfam_un + "/proteome",
+            f"/api/entry/interpro/{acc}/proteome",
+            f"/api/entry/pfam/{pfam}/proteome",
+            f"/api/entry/pfam/{pfam_un}/proteome",
+            f"/api/entry/interpro/{acc}/pfam/{pfam}/proteome",
+            f"/api/entry/interpro/pfam/{pfam}/proteome",
+            f"/api/entry/unintegrated/pfam/{pfam_un}/proteome",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn(
                 "proteomes",
@@ -122,9 +118,7 @@ class EntryProteomeTest(InterproRESTTestCase):
     def test_can_filter_entry_counter_with_proteome_db(self):
         url = "/api/entry/proteome/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(
             "proteomes",
             response.data["entries"]["integrated"],
@@ -143,13 +137,11 @@ class EntryProteomeTest(InterproRESTTestCase):
             "/api/entry/pfam/proteome/uniprot",
             "/api/entry/interpro/pfam/proteome/uniprot",
             "/api/entry/unintegrated/pfam/proteome/uniprot",
-            "/api/entry/interpro/" + acc + "/pfam/proteome/uniprot",
+            f"/api/entry/interpro/{acc}/pfam/proteome/uniprot",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -169,9 +161,7 @@ class EntryProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn("proteome_subset", response.data)
             for org in response.data["proteome_subset"]:
@@ -184,9 +174,7 @@ class EntryProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_count_overview(response.data)
 
     def test_can_get_the_proteome_object_on_a_list(self):
@@ -194,13 +182,11 @@ class EntryProteomeTest(InterproRESTTestCase):
         urls = [
             "/api/entry/pfam/proteome/uniprot/UP000006701",
             "/api/entry/interpro/pfam/proteome/uniprot/UP000006701",
-            "/api/entry/interpro/" + acc + "/pfam/proteome/uniprot/UP000006701",
+            f"/api/entry/interpro/{acc}/pfam/proteome/uniprot/UP000006701",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -220,9 +206,7 @@ class EntryProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
             self.assertIn("proteomes", response.data)
             for org in response.data["proteomes"]:
@@ -244,9 +228,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -260,16 +242,14 @@ class ProteinProteomeTest(InterproRESTTestCase):
         reviewed = "A1CUJ5"
         unreviewed = "P16582"
         urls = [
-            "/api/protein/uniprot/" + reviewed + "/proteome/",
-            "/api/protein/uniprot/" + unreviewed + "/proteome/",
-            "/api/protein/reviewed/" + reviewed + "/proteome/",
-            "/api/protein/unreviewed/" + unreviewed + "/proteome/",
+            f"/api/protein/uniprot/{reviewed}/proteome/",
+            f"/api/protein/uniprot/{unreviewed}/proteome/",
+            f"/api/protein/reviewed/{reviewed}/proteome/",
+            f"/api/protein/unreviewed/{unreviewed}/proteome/",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn(
                 "proteomes",
@@ -281,9 +261,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
     def test_can_filter_protein_counter_with_proteome_db(self):
         url = "/api/protein/proteome/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(
             "proteins",
             response.data["proteins"]["uniprot"],
@@ -325,9 +303,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -346,9 +322,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn("proteome_subset", response.data)
             for org in response.data["proteome_subset"]:
@@ -361,9 +335,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_count_overview(response.data)
 
     def test_can_get_the_proteome_object_on_a_list(self):
@@ -373,9 +345,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -393,9 +363,7 @@ class ProteinProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
             self.assertIn("proteomes", response.data)
             for org in response.data["proteomes"]:
@@ -412,9 +380,7 @@ class StructureProteomeTest(InterproRESTTestCase):
     def test_can_get_the_proteome_count_on_a_list(self):
         url = "/api/structure/pdb/proteome/"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "proteomes")
         for result in response.data["results"]:
@@ -422,14 +388,11 @@ class StructureProteomeTest(InterproRESTTestCase):
 
     def test_urls_that_return_structure_with_proteome_count(self):
         urls = [
-            "/api/structure/pdb/" + pdb + "/proteome/"
-            for pdb in ["1JM7", "2BKM", "1T2V"]
+            f"/api/structure/pdb/{pdb}/proteome/" for pdb in ["1JM7", "2BKM", "1T2V"]
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn(
                 "proteomes",
@@ -441,9 +404,7 @@ class StructureProteomeTest(InterproRESTTestCase):
     def test_can_filter_structure_counter_with_proteome_db(self):
         url = "/api/structure/proteome/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIn(
             "structures",
             response.data["structures"]["pdb"],
@@ -458,9 +419,7 @@ class StructureProteomeTest(InterproRESTTestCase):
     def test_can_get_the_proteome_list_on_a_list(self):
         url = "/api/structure/pdb/proteome/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(
             response.data["results"], "proteome_subset"
@@ -477,9 +436,7 @@ class StructureProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn("proteome_subset", response.data)
             for org in response.data["proteome_subset"]:
@@ -492,9 +449,7 @@ class StructureProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_count_overview(response.data)
 
     def test_can_get_the_proteome_object_on_a_list(self):
@@ -504,9 +459,7 @@ class StructureProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -524,9 +477,7 @@ class StructureProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
             self.assertIn("proteomes", response.data)
             for org in response.data["proteomes"]:
@@ -548,9 +499,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -568,9 +517,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn(
                 "proteomes",
@@ -582,9 +529,7 @@ class SetProteomeTest(InterproRESTTestCase):
     def test_can_filter_set_counter_with_structure_db(self):
         url = "/api/set/proteome/uniprot"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIsInstance(response.data, dict)
         # if "kegg" in response.data["sets"]:
         #     self.assertIn("proteomes", response.data["sets"]["kegg"],
@@ -611,9 +556,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -632,9 +575,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
             self.assertIn("proteome_subset", response.data)
             for st in response.data["proteome_subset"]:
@@ -647,9 +588,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_count_overview(response.data)
 
     def test_can_get_object_on_a_set_list(self):
@@ -661,9 +600,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -683,9 +620,7 @@ class SetProteomeTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"])
             self.assertIn("proteomes", response.data)
             for s in response.data["proteomes"]:
@@ -702,9 +637,7 @@ class ProteomeEntryTest(InterproRESTTestCase):
     def test_can_get_the_entry_count_on_a_list(self):
         url = "/api/proteome/uniprot/entry"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "entries")
         for result in response.data["results"]:
@@ -717,9 +650,7 @@ class ProteomeEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn(
                 "entries",
@@ -736,13 +667,11 @@ class ProteomeEntryTest(InterproRESTTestCase):
             "/api/proteome/entry/unintegrated",
             "/api/proteome/entry/unintegrated/pfam",
             "/api/proteome/entry/interpro/pfam",
-            "/api/proteome/entry/interpro/" + acc + "/pfam",
+            f"/api/proteome/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             self.assertIn(
                 "uniprot",
@@ -770,19 +699,15 @@ class ProteomeEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "entries_url"
             )
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            response = self.client.get(f"{url}?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -804,15 +729,11 @@ class ProteomeEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
             self.assertIn("entries_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            response = self.client.get(f"{url}?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
             self.assertIn("entry_subset", response.data)
             for st in response.data["entry_subset"]:
@@ -823,18 +744,16 @@ class ProteomeEntryTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/proteome/entry/interpro/" + acc,
-            "/api/proteome/entry/pfam/" + pfam,
-            "/api/proteome/entry/pfam/" + pfam_un,
-            "/api/proteome/entry/interpro/" + acc + "/pfam/" + pfam,
-            "/api/proteome/entry/interpro/pfam/" + pfam,
-            "/api/proteome/entry/unintegrated/pfam/" + pfam_un,
+            f"/api/proteome/entry/interpro/{acc}",
+            f"/api/proteome/entry/pfam/{pfam}",
+            f"/api/proteome/entry/pfam/{pfam_un}",
+            f"/api/proteome/entry/interpro/{acc}/pfam/{pfam}",
+            f"/api/proteome/entry/interpro/pfam/{pfam}",
+            f"/api/proteome/entry/unintegrated/pfam/{pfam_un}",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_count_overview(response.data)
 
     def test_can_get_object_on_a_proteome_list(self):
@@ -842,19 +761,17 @@ class ProteomeEntryTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_un = "PF17176"
         urls = [
-            "/api/proteome/uniprot/entry/interpro/" + acc,
-            "/api/proteome/uniprot/entry/pfam/" + pfam,
-            "/api/proteome/uniprot/entry/unintegrated/pfam/" + pfam_un,
-            "/api/proteome/uniprot/entry/unintegrated/pfam/" + pfam_un,
-            "/api/proteome/uniprot/entry/interpro/pfam/" + pfam,
-            "/api/proteome/uniprot/entry/unintegrated/pfam/" + pfam_un,
-            "/api/proteome/uniprot/entry/interpro/IPR003165/pfam/" + pfam,
+            f"/api/proteome/uniprot/entry/interpro/{acc}",
+            f"/api/proteome/uniprot/entry/pfam/{pfam}",
+            f"/api/proteome/uniprot/entry/unintegrated/pfam/{pfam_un}",
+            f"/api/proteome/uniprot/entry/unintegrated/pfam/{pfam_un}",
+            f"/api/proteome/uniprot/entry/interpro/pfam/{pfam}",
+            f"/api/proteome/uniprot/entry/unintegrated/pfam/{pfam_un}",
+            f"/api/proteome/uniprot/entry/interpro/IPR003165/pfam/{pfam}",
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -874,9 +791,7 @@ class ProteomeEntryTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
             self.assertIn("entries", response.data)
             for st in response.data["entries"]:
@@ -893,9 +808,7 @@ class ProteomeProteinTest(InterproRESTTestCase):
     def test_can_get_the_protein_count_on_a_list(self):
         url = "/api/proteome/uniprot/protein"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "proteins")
         for result in response.data["results"]:
@@ -909,9 +822,7 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn(
                 "proteins",
@@ -928,9 +839,7 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIsInstance(response.data, dict)
             self.assertIn(
                 "uniprot",
@@ -956,12 +865,14 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "proteins_url"
+            )
+            response = self.client.get(url + "?show-subset")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "protein_subset"
             )
@@ -978,10 +889,10 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
+            self.assertIn("proteins_url", response.data)
+            response = self.client.get(url + "?show-subset")
             self.assertIn("protein_subset", response.data)
             for st in response.data["protein_subset"]:
                 self._check_match(st, include_coordinates=False)
@@ -994,9 +905,7 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_count_overview(response.data)
 
     def test_can_get_object_on_a_proteome_list(self):
@@ -1008,9 +917,7 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1030,9 +937,7 @@ class ProteomeProteinTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
             self.assertIn("proteins", response.data)
             for st in response.data["proteins"]:
@@ -1049,9 +954,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
     def test_can_get_the_protein_count_on_a_list(self):
         url = "/api/proteome/uniprot/structure"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "structures")
         for result in response.data["results"]:
@@ -1064,9 +967,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn(
                 "structures",
@@ -1083,9 +984,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn(
                 "structures",
@@ -1097,9 +996,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
     def test_can_filter_structure_counter_with_proteome_db(self):
         url = "/api/proteome/structure/pdb"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIsInstance(response.data, dict)
         self.assertIn(
             "uniprot",
@@ -1120,9 +1017,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
     def test_can_get_a_list_from_the_proteome_list(self):
         url = "/api/proteome/uniprot/structure/pdb"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(
             response.data["results"], "structure_subset"
@@ -1139,9 +1034,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
             self.assertIn("structure_subset", response.data)
             for st in response.data["structure_subset"]:
@@ -1151,9 +1044,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
         urls = ["/api/proteome/structure/pdb/1JM7", "/api/proteome/structure/pdb/1JZ8"]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_count_overview(response.data)
 
     def test_can_get_object_on_a_proteome_list(self):
@@ -1163,9 +1054,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1184,9 +1073,7 @@ class ProteomeStructureTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"], False)
             self.assertIn("structures", response.data)
             for st in response.data["structures"]:
@@ -1203,9 +1090,7 @@ class ProteomeSetTest(InterproRESTTestCase):
     def test_can_get_the_set_count_on_a_list(self):
         url = "/api/proteome/uniprot/set"
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(response.data["results"], "sets")
         for result in response.data["results"]:
@@ -1218,9 +1103,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn(
                 "sets",
@@ -1237,9 +1120,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn(
                 "uniprot",
                 response.data["proteomes"],
@@ -1264,9 +1145,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1285,9 +1164,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn("set_subset", response.data)
             for s in response.data["set_subset"]:
@@ -1302,9 +1179,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
@@ -1315,9 +1190,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
@@ -1334,9 +1207,7 @@ class ProteomeSetTest(InterproRESTTestCase):
         ]
         for url in urls:
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL : [{}]".format(url)
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_proteome_details(response.data["metadata"])
             self.assertIn("sets", response.data)
             for s in response.data["sets"]:

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -479,8 +479,6 @@ class SetProteomeTest(InterproRESTTestCase):
     def test_can_get_the_proteome_count_on_a_list(self):
         urls = [
             "/api/set/pfam/proteome",
-            #            "/api/set/kegg/proteome",
-            #            "/api/set/kegg/KEGG01/node/proteome",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -497,8 +495,6 @@ class SetProteomeTest(InterproRESTTestCase):
     def test_can_get_the_proteome_count_on_a_set(self):
         urls = [
             "/api/set/pfam/CL0001/proteome",
-            #            "/api/set/kegg/KEGG01/proteome",
-            #            "/api/set/kegg/KEGG01/node/KEGG01-1/proteome",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -516,11 +512,6 @@ class SetProteomeTest(InterproRESTTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self.assertIsInstance(response.data, dict)
-        # if "kegg" in response.data["sets"]:
-        #     self.assertIn("proteomes", response.data["sets"]["kegg"],
-        #                   "'proteomes' should be one of the keys in the response")
-        #     self.assertIn("sets", response.data["sets"]["kegg"],
-        #                   "'sets' should be one of the keys in the response")
         if "pfam" in response.data["sets"]:
             self.assertIn(
                 "proteomes",
@@ -568,10 +559,7 @@ class SetProteomeTest(InterproRESTTestCase):
 
     def test_can_get_object_on_a_set_list(self):
         urls = [
-            #            "/api/set/kegg/proteome/uniprot/up000030104",
-            #            "/api/set/kegg/proteome/uniprot/up000006701",
             "/api/set/pfam/proteome/uniprot/UP000012042",
-            #            "/api/set/kegg/kegg01/node/proteome/uniprot/up000030104",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -588,11 +576,7 @@ class SetProteomeTest(InterproRESTTestCase):
                     self._check_proteome_from_searcher(st)
 
     def test_can_get_an_object_from_the_set_object(self):
-        urls = [
-            #            "/api/set/kegg/kegg01/proteome/uniprot/UP000006701",
-            #            "/api/set/kegg/kegg01/node/kegg01-1/proteome/uniprot/UP000006701",
-            "/api/set/pfam/Cl0001/proteome/uniprot/UP000006701"
-        ]
+        urls = ["/api/set/pfam/Cl0001/proteome/uniprot/UP000006701"]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
@@ -1062,8 +1046,6 @@ class ProteomeSetTest(InterproRESTTestCase):
     def test_can_filter_proteome_counter_with_proteome_db(self):
         urls = [
             "/api/proteome/set/pfam",
-            #            "/api/proteome/set/kegg",
-            #            "/api/proteome/set/kegg/kegg01/node",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -1098,8 +1080,6 @@ class ProteomeSetTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_proteome_object(self):
         urls = [
             "/api/proteome/uniprot/UP000006701/set/pfam",
-            #            "/api/proteome/uniprot/UP000006701/set/kegg",
-            #            "/api/proteome/uniprot/UP000006701/set/kegg/kegg01/node",
         ]
         for url in urls:
             self._check_details_url_with_and_without_subset(
@@ -1112,9 +1092,6 @@ class ProteomeSetTest(InterproRESTTestCase):
     def test_can_filter_counter_with_set_acc(self):
         urls = [
             "/api/proteome/set/pfam/Cl0001",
-            #            "/api/proteome/set/kegg/kegg01",
-            #            "/api/proteome/set/kegg/kegg01/node/KEGG01-1",
-            #            "/api/proteome/set/kegg/kegg01/node/KEGG01-2",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -1122,11 +1099,7 @@ class ProteomeSetTest(InterproRESTTestCase):
             self._check_proteome_count_overview(response.data)
 
     def test_can_get_the_set_object_on_a_list(self):
-        urls = [
-            #            "/api/proteome/uniprot/set/kegg/kegg01",
-            #            "/api/proteome/uniprot/set/kegg/kegg01/node/kegg01-1",
-            "/api/proteome/uniprot/set/pfam/Cl0001"
-        ]
+        urls = ["/api/proteome/uniprot/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
@@ -1139,11 +1112,7 @@ class ProteomeSetTest(InterproRESTTestCase):
                     self._check_set_from_searcher(org)
 
     def test_can_get_the_object_on_an_object(self):
-        urls = [
-            #            "/api/proteome/uniprot/UP000006701/set/kegg/kegg01",
-            #            "/api/proteome/uniprot/UP000006701/set/kegg/kegg01/node/kegg01-1",
-            "/api/proteome/uniprot/UP000006701/set/pfam/Cl0001"
-        ]
+        urls = ["/api/proteome/uniprot/UP000006701/set/pfam/Cl0001"]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -1163,21 +1163,13 @@ class ProteomeSetTest(InterproRESTTestCase):
     def test_can_get_the_set_list_on_a_list(self):
         urls = [
             "/api/proteome/uniprot/set/pfam",
-            #            "/api/proteome/uniprot/set/kegg",
-            #            "/api/proteome/uniprot/set/kegg/kegg01/node",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "set_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["set_subset"]:
-                    self._check_set_from_searcher(s)
 
     def test_can_get_the_set_list_on_a_proteome_object(self):
         urls = [
@@ -1186,12 +1178,12 @@ class ProteomeSetTest(InterproRESTTestCase):
             #            "/api/proteome/uniprot/UP000006701/set/kegg/kegg01/node",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_proteome_details(response.data["metadata"])
-            self.assertIn("set_subset", response.data)
-            for s in response.data["set_subset"]:
-                self._check_set_from_searcher(s)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "set",
+                inner_subset_check_fn=self._check_set_from_searcher,
+                check_metadata_fn=self._check_proteome_details,
+            )
 
     def test_can_filter_counter_with_set_acc(self):
         urls = [

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -1043,16 +1043,12 @@ class ProteomeStructureTest(InterproRESTTestCase):
 
     def test_can_get_a_list_from_the_proteome_list(self):
         url = "/api/proteome/uniprot/structure/pdb"
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-        self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self._check_is_list_of_objects_with_key(
-            response.data["results"], "structure_subset"
+        self._check_list_url_with_and_without_subset(
+            url,
+            "structure",
+            check_metadata_fn=lambda m: self._check_proteome_details(m, False),
+            inner_subset_check_fn=self._check_structure_chain_details,
         )
-        for result in response.data["results"]:
-            self._check_proteome_details(result["metadata"], False)
-            for st in result["structure_subset"]:
-                self._check_structure_chain_details(st)
 
     def test_can_get_a_list_from_the_proteome_object(self):
         urls = [
@@ -1060,12 +1056,12 @@ class ProteomeStructureTest(InterproRESTTestCase):
             "/api/proteome/uniprot/UP000030104/structure/pdb",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_proteome_details(response.data["metadata"], False)
-            self.assertIn("structure_subset", response.data)
-            for st in response.data["structure_subset"]:
-                self._check_structure_chain_details(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "structure",
+                check_metadata_fn=lambda m: self._check_proteome_details(m, False),
+                inner_subset_check_fn=self._check_structure_chain_details,
+            )
 
     def test_can_filter_proteome_counter_with_acc(self):
         urls = ["/api/proteome/structure/pdb/1JM7", "/api/proteome/structure/pdb/1JZ8"]

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -140,21 +140,11 @@ class EntryProteomeTest(InterproRESTTestCase):
             f"/api/entry/interpro/{acc}/pfam/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteomes_url"
-            )
-            response = self.client.get(url + "?show-subset")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteome_subset"
-            )
-            for result in response.data["results"]:
-                for org in result["proteome_subset"]:
-                    self._check_proteome_from_searcher(org)
 
     def test_can_get_the_proteome_list_on_an_object(self):
         urls = [
@@ -164,15 +154,12 @@ class EntryProteomeTest(InterproRESTTestCase):
             "/api/entry/interpro/IPR003165/pfam/PF02171/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_entry_details(response.data["metadata"])
-            self.assertIn("proteomes_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self.assertIn("proteome_subset", response.data)
-            for org in response.data["proteome_subset"]:
-                self._check_proteome_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
+                check_metadata_fn=self._check_entry_details,
+            )
 
     def test_can_filter_entry_counter_with_proteome_acc(self):
         urls = [
@@ -309,22 +296,11 @@ class ProteinProteomeTest(InterproRESTTestCase):
             "/api/protein/reviewed/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteomes_url"
-            )
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteome_subset"
-            )
-            for result in response.data["results"]:
-                for org in result["proteome_subset"]:
-                    self._check_proteome_from_searcher(org)
 
     def test_can_get_the_proteome_list_on_an_object(self):
         urls = [
@@ -333,15 +309,13 @@ class ProteinProteomeTest(InterproRESTTestCase):
             "/api/protein/reviewed/A1CUJ5/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_protein_details(response.data["metadata"])
-            self.assertIn("proteomes_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self.assertIn("proteome_subset", response.data)
-            for org in response.data["proteome_subset"]:
-                self._check_proteome_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
+                check_metadata_fn=self._check_protein_details,
+                check_subset_fn=lambda s: self.assertEqual(len(s), 1),
+            )
 
     def test_can_filter_counter_with_proteome_acc(self):
         urls = [
@@ -433,20 +407,11 @@ class StructureProteomeTest(InterproRESTTestCase):
 
     def test_can_get_the_proteome_list_on_a_list(self):
         url = "/api/structure/pdb/proteome/uniprot"
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-        self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
-        self._check_is_list_of_objects_with_key(
-            response.data["results"], "proteomes_url"
+        self._check_list_url_with_and_without_subset(
+            url,
+            "proteome",
+            check_inner_subset_fn=self._check_proteome_from_searcher,
         )
-        response = self.client.get(url + "?show-subset")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-        self._check_is_list_of_objects_with_key(
-            response.data["results"], "proteome_subset"
-        )
-        for result in response.data["results"]:
-            for org in result["proteome_subset"]:
-                self._check_proteome_from_searcher(org)
 
     def test_can_get_the_proteome_list_on_an_object(self):
         urls = [
@@ -455,15 +420,12 @@ class StructureProteomeTest(InterproRESTTestCase):
             "/api/structure/pdb/1JM7/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_structure_details(response.data["metadata"])
-            self.assertIn("proteomes_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self.assertIn("proteome_subset", response.data)
-            for org in response.data["proteome_subset"]:
-                self._check_proteome_from_searcher(org)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
+                check_metadata_fn=self._check_structure_details,
+            )
 
     def test_can_filter_counter_with_proteome_acc(self):
         urls = [
@@ -576,37 +538,23 @@ class SetProteomeTest(InterproRESTTestCase):
             "/api/set/pfam/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteomes_url"
-            )
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "proteome_subset"
-            )
-            for result in response.data["results"]:
-                for s in result["proteome_subset"]:
-                    self._check_proteome_from_searcher(s)
 
     def test_can_get_a_list_from_the_set_object(self):
         urls = [
             "/api/set/pfam/Cl0001/proteome/uniprot",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_set_details(response.data["metadata"], True)
-            self.assertIn("proteomes_url", response.data)
-            response = self.client.get(url + "?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self.assertIn("proteome_subset", response.data)
-            for st in response.data["proteome_subset"]:
-                self._check_proteome_from_searcher(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "proteome",
+                check_inner_subset_fn=self._check_proteome_from_searcher,
+                check_metadata_fn=self._check_set_details,
+            )
 
     def test_can_filter_set_counter_with_acc(self):
         urls = [

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -725,26 +725,14 @@ class ProteomeEntryTest(InterproRESTTestCase):
             "/api/proteome/uniprot/entry/interpro/IPR003165/pfam",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
+            self._check_list_url_with_and_without_subset(
+                url,
+                "entry",
+                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_metadata_fn=lambda metadata: self._check_proteome_details(
+                    metadata, False
+                ),
             )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "entries_url"
-            )
-            response = self.client.get(f"{url}?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "metadata"
-            )
-            self._check_is_list_of_objects_with_key(
-                response.data["results"], "entry_subset"
-            )
-            for result in response.data["results"]:
-                self._check_proteome_details(result["metadata"], False)
-                for st in result["entry_subset"]:
-                    self._check_entry_from_searcher(st)
 
     def test_can_get_a_list_from_the_proteome_object(self):
         urls = [
@@ -755,16 +743,12 @@ class ProteomeEntryTest(InterproRESTTestCase):
             "/api/proteome/uniprot/UP000006701/entry/interpro/IPR003165/smart",
         ]
         for url in urls:
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_proteome_details(response.data["metadata"], False)
-            self.assertIn("entries_url", response.data)
-            response = self.client.get(f"{url}?show-subset")
-            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
-            self._check_proteome_details(response.data["metadata"], False)
-            self.assertIn("entry_subset", response.data)
-            for st in response.data["entry_subset"]:
-                self._check_entry_from_searcher(st)
+            self._check_details_url_with_and_without_subset(
+                url,
+                "entry",
+                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_metadata_fn=self._check_proteome_details,
+            )
 
     def test_can_filter_proteome_counter_with_acc(self):
         acc = "IPR003165"

--- a/webfront/tests/tests_proteome.py
+++ b/webfront/tests/tests_proteome.py
@@ -146,6 +146,10 @@ class EntryProteomeTest(InterproRESTTestCase):
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
+                response.data["results"], "proteomes_url"
+            )
+            response = self.client.get(url + "?show-subset")
+            self._check_is_list_of_objects_with_key(
                 response.data["results"], "proteome_subset"
             )
             for result in response.data["results"]:
@@ -163,6 +167,9 @@ class EntryProteomeTest(InterproRESTTestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_entry_details(response.data["metadata"])
+            self.assertIn("proteomes_url", response.data)
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn("proteome_subset", response.data)
             for org in response.data["proteome_subset"]:
                 self._check_proteome_from_searcher(org)
@@ -308,6 +315,11 @@ class ProteinProteomeTest(InterproRESTTestCase):
                 response.data["results"], "metadata"
             )
             self._check_is_list_of_objects_with_key(
+                response.data["results"], "proteomes_url"
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
+            self._check_is_list_of_objects_with_key(
                 response.data["results"], "proteome_subset"
             )
             for result in response.data["results"]:
@@ -324,6 +336,9 @@ class ProteinProteomeTest(InterproRESTTestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_protein_details(response.data["metadata"])
+            self.assertIn("proteomes_url", response.data)
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn("proteome_subset", response.data)
             for org in response.data["proteome_subset"]:
                 self._check_proteome_from_searcher(org)
@@ -422,6 +437,11 @@ class StructureProteomeTest(InterproRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
         self._check_is_list_of_objects_with_key(response.data["results"], "metadata")
         self._check_is_list_of_objects_with_key(
+            response.data["results"], "proteomes_url"
+        )
+        response = self.client.get(url + "?show-subset")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
+        self._check_is_list_of_objects_with_key(
             response.data["results"], "proteome_subset"
         )
         for result in response.data["results"]:
@@ -438,6 +458,9 @@ class StructureProteomeTest(InterproRESTTestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_structure_details(response.data["metadata"])
+            self.assertIn("proteomes_url", response.data)
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn("proteome_subset", response.data)
             for org in response.data["proteome_subset"]:
                 self._check_proteome_from_searcher(org)
@@ -550,9 +573,7 @@ class SetProteomeTest(InterproRESTTestCase):
 
     def test_can_get_the_set_list_on_a_list(self):
         urls = [
-            #            "/api/set/kegg/proteome/uniprot",
             "/api/set/pfam/proteome/uniprot",
-            #            "/api/set/kegg/kegg01/node/proteome/uniprot",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -560,6 +581,11 @@ class SetProteomeTest(InterproRESTTestCase):
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
             )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "proteomes_url"
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "proteome_subset"
             )
@@ -570,13 +596,14 @@ class SetProteomeTest(InterproRESTTestCase):
     def test_can_get_a_list_from_the_set_object(self):
         urls = [
             "/api/set/pfam/Cl0001/proteome/uniprot",
-            #            "/api/set/kegg/kegg01/proteome/uniprot",
-            #            "/api/set/kegg/kegg01/node/KEGG01-1/proteome/uniprot",
         ]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self._check_set_details(response.data["metadata"], True)
+            self.assertIn("proteomes_url", response.data)
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"URL : [{url}]")
             self.assertIn("proteome_subset", response.data)
             for st in response.data["proteome_subset"]:
                 self._check_proteome_from_searcher(st)

--- a/webfront/tests/tests_structure_endpoint_entry_filter.py
+++ b/webfront/tests/tests_structure_endpoint_entry_filter.py
@@ -108,6 +108,16 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             )
             self._check_is_list_of_objects_with_key(
                 response.data["results"],
+                "entries_url",
+                "It should have the key 'entries_url' for the URL [" + url + "]",
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self._check_is_list_of_objects_with_key(
+                response.data["results"], "metadata"
+            )
+            self._check_is_list_of_objects_with_key(
+                response.data["results"],
                 "entry_subset",
                 "It should have the key 'entry_subset' for the URL [" + url + "]",
             )
@@ -139,6 +149,13 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self._check_structure_details(response.data["metadata"])
+            self.assertIn(
+                "entries_url",
+                response.data,
+                "'entries_url' should be one of the keys in the response",
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(
                 "entry_subset",
                 response.data,
@@ -178,6 +195,13 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self._check_structure_details(response.data["metadata"])
+            self.assertIn(
+                "entries_url",
+                response.data,
+                "'entries_url' should be one of the keys in the response",
+            )
+            response = self.client.get(url + "?show-subset")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(
                 "entry_subset",
                 response.data,

--- a/webfront/tests/tests_structure_endpoint_entry_filter.py
+++ b/webfront/tests/tests_structure_endpoint_entry_filter.py
@@ -27,7 +27,7 @@ class StructureWithFilterEntryRESTTest(InterproRESTTestCase):
 
     def test_can_get_entries_from_structure_id(self):
         urls = [
-            "/api/structure/pdb/" + pdb + "/entry/" for pdb in ["1JM7", "2BKM", "1T2V"]
+            f"/api/structure/pdb/{pdb}/entry/" for pdb in ["1JM7", "2BKM", "1T2V"]
         ]
         for url in urls:
             response = self.client.get(url)
@@ -40,7 +40,7 @@ class StructureWithFilterEntryRESTTest(InterproRESTTestCase):
             self._check_entry_count_overview(response.data)
 
     def test_can_get_entries_from_structure_id_chain(self):
-        urls = ["/api/structure/pdb/" + pdb + "/A/entry/" for pdb in ["1JM7", "1T2V"]]
+        urls = [f"/api/structure/pdb/{pdb}/A/entry/" for pdb in ["1JM7", "1T2V"]]
         for url in urls:
             response = self.client.get(url)
             self.assertIn(
@@ -64,7 +64,7 @@ class StructureWithFilterEntryRESTTest(InterproRESTTestCase):
             self._check_HTTP_response_code(
                 url,
                 code=status.HTTP_404_NOT_FOUND,
-                msg="The URL [" + url + "] should've failed.",
+                msg=f"The URL [{url}] should've failed.",
             )
 
 
@@ -77,13 +77,13 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             "/api/structure/entry/unintegrated",
             "/api/structure/entry/unintegrated/pfam",
             "/api/structure/entry/interpro/pfam",
-            "/api/structure/entry/interpro/" + acc + "/pfam",
+            f"/api/structure/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIsInstance(
-                response.data, dict, url + " should have returned a dict"
+                response.data, dict, f"{url} should have returned a dict"
             )
             for prot_db in response.data["structures"]:
                 self.assertEqual(prot_db, "pdb")
@@ -98,7 +98,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             "/api/structure/pdb/entry/unintegrated",
             "/api/structure/pdb/entry/unintegrated/pfam",
             "/api/structure/pdb/entry/interpro/pfam",
-            "/api/structure/pdb/entry/interpro/" + acc + "/pfam",
+            f"/api/structure/pdb/entry/interpro/{acc}/pfam",
         ]
         for url in urls:
             response = self.client.get(url)
@@ -109,9 +109,9 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_is_list_of_objects_with_key(
                 response.data["results"],
                 "entries_url",
-                "It should have the key 'entries_url' for the URL [" + url + "]",
+                f"It should have the key 'entries_url' for the URL [{url}]",
             )
-            response = self.client.get(url + "?show-subset")
+            response = self.client.get(f"{url}?show-subset")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self._check_is_list_of_objects_with_key(
                 response.data["results"], "metadata"
@@ -119,7 +119,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_is_list_of_objects_with_key(
                 response.data["results"],
                 "entry_subset",
-                "It should have the key 'entry_subset' for the URL [" + url + "]",
+                f"It should have the key 'entry_subset' for the URL [{url}]",
             )
             for structure in response.data["results"]:
                 for match in structure["entry_subset"]:
@@ -154,7 +154,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
                 response.data,
                 "'entries_url' should be one of the keys in the response",
             )
-            response = self.client.get(url + "?show-subset")
+            response = self.client.get(f"{url}?show-subset")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(
                 "entry_subset",
@@ -164,7 +164,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self.assertEqual(
                 len(response.data["entry_subset"]),
                 len(urls[url]),
-                "The number of entries should be the same URL: [{}]".format(url),
+                f"The number of entries should be the same URL: [{url}]",
             )
             for entry in response.data["entry_subset"]:
                 self.assertIn(entry["accession"].upper(), urls[url])
@@ -200,7 +200,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
                 response.data,
                 "'entries_url' should be one of the keys in the response",
             )
-            response = self.client.get(url + "?show-subset")
+            response = self.client.get(f"{url}?show-subset")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(
                 "entry_subset",
@@ -210,7 +210,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self.assertEqual(
                 len(response.data["entry_subset"]),
                 len(urls[url]),
-                "The number of entry_subset should be the same. URL: [{}]".format(url),
+                f"The number of entry_subset should be the same. URL: [{url}]",
             )
             for entry in response.data["entry_subset"]:
                 self.assertIn(entry["accession"].upper(), urls[url])
@@ -220,15 +220,15 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
         pdb_2 = "2BKM"
         acc = "IPR003165"
         tests = [
-            "/api/structure/pdb/" + pdb_2 + "/A/entry/unintegrated",
-            "/api/structure/pdb/" + pdb_1 + "/B/entry/interpro",
-            "/api/structure/pdb/" + pdb_2 + "/A/entry/pfam",
-            "/api/structure/pdb/" + pdb_1 + "/B/entry/interpro/pfam",
-            "/api/structure/pdb/" + pdb_1 + "/B/entry/interpro/smart",
-            "/api/structure/pdb/" + pdb_1 + "/B/entry/interpro/" + acc + "/smart",
-            "/api/structure/pdb/" + pdb_1 + "/B/entry/interpro/" + acc + "/pfam",
-            "/api/structure/pdb/" + pdb_2 + "/A/entry/unintegrated/pfam",
-            "/api/structure/pdb/" + pdb_2 + "/B/entry/unintegrated/smart",
+            f"/api/structure/pdb/{pdb_2}/A/entry/unintegrated",
+            f"/api/structure/pdb/{pdb_1}/B/entry/interpro",
+            f"/api/structure/pdb/{pdb_2}/A/entry/pfam",
+            f"/api/structure/pdb/{pdb_1}/B/entry/interpro/pfam",
+            f"/api/structure/pdb/{pdb_1}/B/entry/interpro/smart",
+            f"/api/structure/pdb/{pdb_1}/B/entry/interpro/{acc}/smart",
+            f"/api/structure/pdb/{pdb_1}/B/entry/interpro/{acc}/pfam",
+            f"/api/structure/pdb/{pdb_2}/A/entry/unintegrated/pfam",
+            f"/api/structure/pdb/{pdb_2}/B/entry/unintegrated/smart",
             "/api/structure/pdb/entry/unintegrated/smart",
             "/api/structure/entry/unintegrated/smart",
         ]
@@ -236,7 +236,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_HTTP_response_code(
                 url,
                 code=status.HTTP_204_NO_CONTENT,
-                msg="The URL [" + url + "] should've failed.",
+                msg=f"The URL [{url}] should've failed.",
             )
 
 
@@ -246,16 +246,16 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
         pfam = "PF02171"
         pfam_u = "PF17180"
         urls = [
-            "/api/structure/entry/unintegrated/pfam/" + pfam_u,
-            "/api/structure/entry/interpro/pfam/" + pfam,
-            "/api/structure/entry/pfam/" + pfam,
-            "/api/structure/entry/interpro/" + acc + "/pfam/" + pfam,
-            "/api/structure/entry/interpro/" + acc,
+            f"/api/structure/entry/unintegrated/pfam/{pfam_u}",
+            f"/api/structure/entry/interpro/pfam/{pfam}",
+            f"/api/structure/entry/pfam/{pfam}",
+            f"/api/structure/entry/interpro/{acc}/pfam/{pfam}",
+            f"/api/structure/entry/interpro/{acc}",
         ]
         for url in urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self._check_structure_count_overview(response.data, "URL: [{}]".format(url))
+            self._check_structure_count_overview(response.data, f"URL: [{url}]")
 
     def test_urls_that_return_list_of_structure_accessions_with_matches_and_detailed_entries(
         self,
@@ -265,11 +265,11 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
         pfam_u = "PF17180"
         smart = "SM00950"
         urls = {
-            "/api/structure/pdb/entry/interpro/" + acc: [acc],
-            "/api/structure/pdb/entry/pfam/" + pfam: [pfam],
-            "/api/structure/pdb/entry/unintegrated/pfam/" + pfam_u: [pfam_u],
-            "/api/structure/pdb/entry/interpro/smart/" + smart: [smart],
-            "/api/structure/pdb/entry/interpro/" + acc + "/pfam/" + pfam: [pfam],
+            f"/api/structure/pdb/entry/interpro/{acc}": [acc],
+            f"/api/structure/pdb/entry/pfam/{pfam}": [pfam],
+            f"/api/structure/pdb/entry/unintegrated/pfam/{pfam_u}": [pfam_u],
+            f"/api/structure/pdb/entry/interpro/smart/{smart}": [smart],
+            f"/api/structure/pdb/entry/interpro/{acc}/pfam/{pfam}": [pfam],
         }
         for url in urls:
             response = self.client.get(url)
@@ -280,7 +280,7 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
             self._check_is_list_of_objects_with_key(
                 response.data["results"],
                 "entries",
-                "It should have the key 'entries' for the URL [" + url + "]",
+                f"It should have the key 'entries' for the URL [{url}]",
             )
             for structure in response.data["results"]:
                 for match in structure["entries"]:
@@ -291,7 +291,7 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
         ips = ["IPR001165", "IPR003165"]
         for ip in ips:
             response = self.client.get(
-                "/api/structure/pdb/" + pdb_1 + "/entry/interpro/" + ip
+                f"/api/structure/pdb/{pdb_1}/entry/interpro/{ip}"
             )
             self._check_single_entry_response(response)
 
@@ -327,7 +327,7 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
             self.assertEqual(
                 len(response.data["entries"]),
                 1,
-                "The number of entries should be 1. URL: [{}]".format(url),
+                f"The number of entries should be 1. URL: [{url}]",
             )
             self._check_entry_structure_details(response.data["entries"][0])
 
@@ -345,7 +345,7 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
         ]
         for url in tests:
             self._check_HTTP_response_code(
-                url, msg="The URL [" + url + "] should've failed."
+                url, msg=f"The URL [{url}] should've failed."
             )
 
     def test_urls_that_should_fails(self):
@@ -368,5 +368,5 @@ class StructureWithFilterEntryDatabaseAccessionRESTTest(InterproRESTTestCase):
             self._check_HTTP_response_code(
                 url,
                 code=status.HTTP_204_NO_CONTENT,
-                msg="The URL [" + url + "] should've failed.",
+                msg=f"The URL [{url}] should've failed.",
             )

--- a/webfront/tests/tests_structure_endpoint_entry_filter.py
+++ b/webfront/tests/tests_structure_endpoint_entry_filter.py
@@ -102,7 +102,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_list_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=self._check_entry_from_searcher,
+                check_inner_subset_fn=self._check_entry_from_searcher,
             )
 
     def test_urls_that_return_a_structure_details_with_matches(self):
@@ -129,7 +129,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=lambda entry: self._check_entry_from_searcher(
+                check_inner_subset_fn=lambda entry: self._check_entry_from_searcher(
                     entry
                 )
                 and self.assertIn(entry["accession"].upper(), urls[url]),
@@ -162,7 +162,7 @@ class StructureWithFilterEntryDatabaseRESTTest(InterproRESTTestCase):
             self._check_details_url_with_and_without_subset(
                 url,
                 "entry",
-                inner_subset_check_fn=lambda entry: self._check_entry_from_searcher(
+                check_inner_subset_fn=lambda entry: self._check_entry_from_searcher(
                     entry
                 )
                 and self.assertIn(entry["accession"].upper(), urls[url]),

--- a/webfront/tests/tests_structure_endpoint_protein_filter.py
+++ b/webfront/tests/tests_structure_endpoint_protein_filter.py
@@ -77,7 +77,7 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
                 result,
                 f"Should have the field proteins_url in response",
             )
-            self.asserURL(result["proteins_url"])
+            self.assertURL(result["proteins_url"])
         response = self.client.get("/api/structure/pdb/protein/uniprot?show-subset")
         self.assertEqual(len(response.data["results"]), len(data_in_fixtures))
         for result in response.data["results"]:
@@ -101,7 +101,7 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
                 result,
                 f"Should have the field proteins_url in response",
             )
-            self.asserURL(result["proteins_url"])
+            self.assertURL(result["proteins_url"])
         response = self.client.get("/api/structure/pdb/protein/reviewed?show-subset")
         for result in response.data["results"]:
             for match in result["protein_subset"]:
@@ -123,7 +123,7 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
                 response.data,
                 "'proteins_url' should be one of the keys in the response",
             )
-            self.asserURL(response.data["proteins_url"])
+            self.assertURL(response.data["proteins_url"])
             response = self.client.get(url + "?show-subset")
             self.assertIn(
                 "protein_subset",
@@ -148,7 +148,7 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
                 response.data,
                 "'proteins_url' should be one of the keys in the response",
             )
-            self.asserURL(response.data["proteins_url"])
+            self.assertURL(response.data["proteins_url"])
             response = self.client.get(url + "?show-subset")
             self.assertIn(
                 "protein_subset",

--- a/webfront/tests/tests_structure_endpoint_protein_filter.py
+++ b/webfront/tests/tests_structure_endpoint_protein_filter.py
@@ -34,9 +34,9 @@ class StructureWithFilterProteinRESTTest(InterproRESTTestCase):
     def test_urls_that_return_structure_with_protein_count(self):
         for pdb in data_in_fixtures:
             urls = [
-                "/api/structure/pdb/" + pdb + "/protein",
-                "/api/structure/pdb/" + pdb + "/A/protein/",
-                "/api/structure/pdb/" + pdb + "/B/protein/",
+                f"/api/structure/pdb/{pdb}/protein",
+                f"/api/structure/pdb/{pdb}/A/protein/",
+                f"/api/structure/pdb/{pdb}/B/protein/",
             ]
             for url in urls:
                 response = self.client.get(url)
@@ -72,12 +72,19 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
         response = self.client.get("/api/structure/pdb/protein/uniprot")
         self.assertEqual(len(response.data["results"]), len(data_in_fixtures))
         for result in response.data["results"]:
+            self.assertIn(
+                "proteins_url",
+                result,
+                f"Should have the field proteins_url in response",
+            )
+            self.asserURL(result["proteins_url"])
+        response = self.client.get("/api/structure/pdb/protein/uniprot?show-subset")
+        self.assertEqual(len(response.data["results"]), len(data_in_fixtures))
+        for result in response.data["results"]:
             self.assertEqual(
                 len(result["protein_subset"]),
                 len(data_in_fixtures[result["metadata"]["accession"]]),
-                "different length while testing {}".format(
-                    result["metadata"]["accession"]
-                ),
+                f"different length while testing {result['metadata']['accession']}",
             )
             for match in result["protein_subset"]:
                 self.assertIn(
@@ -89,6 +96,14 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
     def test_can_get_reviewed_from_pdb_structures(self):
         response = self.client.get("/api/structure/pdb/protein/reviewed")
         for result in response.data["results"]:
+            self.assertIn(
+                "proteins_url",
+                result,
+                f"Should have the field proteins_url in response",
+            )
+            self.asserURL(result["proteins_url"])
+        response = self.client.get("/api/structure/pdb/protein/reviewed?show-subset")
+        for result in response.data["results"]:
             for match in result["protein_subset"]:
                 self.assertIn(
                     match["accession"].lower(),
@@ -98,11 +113,18 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
 
     def test_can_get_uniprot_matches_from_structures(self):
         tests = {
-            "/api/structure/pdb/" + pdb + "/protein/uniprot": data_in_fixtures[pdb]
+            f"/api/structure/pdb/{pdb}/protein/uniprot": data_in_fixtures[pdb]
             for pdb in data_in_fixtures
         }
         for url in tests:
             response = self.client.get(url)
+            self.assertIn(
+                "proteins_url",
+                response.data,
+                "'proteins_url' should be one of the keys in the response",
+            )
+            self.asserURL(response.data["proteins_url"])
+            response = self.client.get(url + "?show-subset")
             self.assertIn(
                 "protein_subset",
                 response.data,
@@ -116,11 +138,18 @@ class StructureWithFilterProteinUniprotRESTTest(InterproRESTTestCase):
 
     def test_can_get_uniprot_matches_from_structures_chain(self):
         tests = {
-            "/api/structure/pdb/" + pdb + "/A/protein/uniprot": data_in_fixtures[pdb]
+            f"/api/structure/pdb/{pdb}/A/protein/uniprot": data_in_fixtures[pdb]
             for pdb in data_in_fixtures
         }
         for url in tests:
             response = self.client.get(url)
+            self.assertIn(
+                "proteins_url",
+                response.data,
+                "'proteins_url' should be one of the keys in the response",
+            )
+            self.asserURL(response.data["proteins_url"])
+            response = self.client.get(url + "?show-subset")
             self.assertIn(
                 "protein_subset",
                 response.data,
@@ -138,12 +167,12 @@ class StructureWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         prot_b = "M5ADK6"
 
         tests = {
-            "/api/structure/pdb/" + pdb + "/protein/uniprot/" + prot_a: [prot_a],
-            "/api/structure/pdb/" + pdb + "/protein/uniprot/" + prot_b: [prot_b],
-            "/api/structure/pdb/" + pdb + "/A/protein/uniprot/" + prot_a: [prot_a],
-            "/api/structure/pdb/" + pdb + "/A/protein/reviewed/" + prot_a: [prot_a],
-            "/api/structure/pdb/" + pdb + "/B/protein/uniprot/" + prot_b: [prot_b],
-            "/api/structure/pdb/" + pdb + "/B/protein/reviewed/" + prot_b: [prot_b],
+            f"/api/structure/pdb/{pdb}/protein/uniprot/{prot_a}": [prot_a],
+            f"/api/structure/pdb/{pdb}/protein/uniprot/{prot_b}": [prot_b],
+            f"/api/structure/pdb/{pdb}/A/protein/uniprot/{prot_a}": [prot_a],
+            f"/api/structure/pdb/{pdb}/A/protein/reviewed/{prot_a}": [prot_a],
+            f"/api/structure/pdb/{pdb}/B/protein/uniprot/{prot_b}": [prot_b],
+            f"/api/structure/pdb/{pdb}/B/protein/reviewed/{prot_b}": [prot_b],
         }
         for url in tests:
             response = self.client.get(url)
@@ -163,10 +192,15 @@ class StructureWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         prot_t = "P16582"
 
         tests = {
-            "/api/structure/pdb/protein/uniprot/" + prot_s: ["2BKM", "1JM7"],
-            "/api/structure/pdb/protein/reviewed/" + prot_s: ["2BKM", "1JM7"],
-            "/api/structure/pdb/protein/unreviewed/"
-            + prot_t: ["1T2V", "1T2V", "1T2V", "1T2V", "1T2V"],
+            f"/api/structure/pdb/protein/uniprot/{prot_s}": ["2BKM", "1JM7"],
+            f"/api/structure/pdb/protein/reviewed/{prot_s}": ["2BKM", "1JM7"],
+            f"/api/structure/pdb/protein/unreviewed/{prot_t}": [
+                "1T2V",
+                "1T2V",
+                "1T2V",
+                "1T2V",
+                "1T2V",
+            ],
         }
         for url in tests:
             response = self.client.get(url)
@@ -187,7 +221,7 @@ class StructureWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
 
     def test_can_get_proteins_from_structure_protein_id(self):
         prot_s = "M5ADK6"
-        response = self.client.get("/api/structure/protein/uniprot/" + prot_s)
+        response = self.client.get(f"/api/structure/protein/uniprot/{prot_s}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self._check_structure_count_overview(response.data)
         # TODO: improve this test
@@ -197,40 +231,40 @@ class StructureWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
         prot_s = "M5ADK6"
         prot_t = "P16582"
         tests = [
-            "/api/structure/pdb/" + pdb + "/protein/uniprot/bad_uniprot",
-            "/api/structure/pdb/" + pdb + "/protein/unreviewed/" + prot_s,
-            "/api/structure/pdb/protein/unreviewed/" + prot_s,
-            "/api/structure/pdb/protein/reviewed/" + prot_t,
+            f"/api/structure/pdb/{pdb}/protein/uniprot/bad_uniprot",
+            f"/api/structure/pdb/{pdb}/protein/unreviewed/{prot_s}",
+            f"/api/structure/pdb/protein/unreviewed/{prot_s}",
+            f"/api/structure/pdb/protein/reviewed/{prot_t}",
         ]
         for url in tests:
             self._check_HTTP_response_code(
-                url, msg="The URL [" + url + "] should've failed."
+                url, msg=f"The URL [{url}] should've failed."
             )
 
     def test_urls_that_should_fail(self):
         pdb = "1JM7"
         prot_s = "M5ADK6"
         tests = [
-            "/api/structure/pdb/bad_structure/protein/uniprot/" + prot_s,
-            "/api/bad_endpoint/pdb/" + pdb + "/protein/uniprot/" + prot_s,
-            "/api/structure/bad_db/" + pdb + "/protein/uniprot/" + prot_s,
-            "/api/structure/pdb/" + pdb + "/protein/uniprot/bad_protein",
-            "/api/structure/pdb/" + pdb + "/protein/bad_db/" + prot_s,
-            "/api/structure/pdb/" + pdb + "/bad_endpoint/uniprot/" + prot_s,
+            f"/api/structure/pdb/bad_structure/protein/uniprot/{prot_s}",
+            f"/api/bad_endpoint/pdb/{pdb}/protein/uniprot/{prot_s}",
+            f"/api/structure/bad_db/{pdb}/protein/uniprot/{prot_s}",
+            f"/api/structure/pdb/{pdb}/protein/uniprot/bad_protein",
+            f"/api/structure/pdb/{pdb}/protein/bad_db/{prot_s}",
+            f"/api/structure/pdb/{pdb}/bad_endpoint/uniprot/{prot_s}",
         ]
         for url in tests:
             self._check_HTTP_response_code(
                 url,
                 code=status.HTTP_404_NOT_FOUND,
-                msg="The URL [" + url + "] should've failed.",
+                msg=f"The URL [{url}] should've failed.",
             )
         tests = [
-            "/api/structure/pdb/BADP/protein/uniprot/" + prot_s,
-            "/api/structure/pdb/" + pdb + "/protein/uniprot/bad_prot",
+            f"/api/structure/pdb/BADP/protein/uniprot/{prot_s}",
+            f"/api/structure/pdb/{pdb}/protein/uniprot/bad_prot",
         ]
         for url in tests:
             self._check_HTTP_response_code(
                 url,
                 code=status.HTTP_204_NO_CONTENT,
-                msg="The URL [" + url + "] should've failed.",
+                msg=f"The URL [{url}] should've failed.",
             )

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -31,7 +31,7 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
-endpoints_with_url = ["entry", "protein", "structure", "proteome"]
+endpoints_with_url = ["entry", "protein", "structure", "proteome", "set"]
 
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -31,7 +31,7 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
-endpoints_with_url = ["entry"]
+endpoints_with_url = ["entry", "protein"]
 
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
@@ -1466,7 +1466,6 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for db3 in api_test_map[endpoint3]:
                                 for acc1 in api_test_map[endpoint1][db1]:
-                                    # TODO: ❇️ Remember the git stash
                                     # /[endpoint]/[db]/[endpoint]/[db]/[acc]/[endpoint]/[db]
                                     current = f"/api/{endpoint2}/{db2}/{endpoint1}/{db1}/{acc1}/{endpoint3}/{db3}"
                                     response = self._get_in_debug_mode(current)

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -31,7 +31,7 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
-endpoints_with_url = ["entry", "protein", "proteome"]
+endpoints_with_url = ["entry", "protein", "structure", "proteome"]
 
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
@@ -251,7 +251,7 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                         msg=f"URL : [{current}]",
                                     )
                                 else:
-                                    self.asserURL(
+                                    self.assertURL(
                                         result,
                                         f"The URL in {key2}: {result} is not valid | URL: {current}",
                                     )
@@ -347,7 +347,7 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                         msg=f"URL : [{current}]",
                                     )
                                 else:
-                                    self.asserURL(
+                                    self.assertURL(
                                         response.data[key],
                                         f"The URL in {key}: {response.data[key]} is not valid | URL: {current}",
                                     )
@@ -717,7 +717,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             msg=f"URL : [{current}]",
                                         )
                                     else:
-                                        self.asserURL(
+                                        self.assertURL(
                                             result,
                                             f"The URL in {key}: {result} is not valid | URL: {current}",
                                         )
@@ -770,7 +770,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             msg=f"URL : [{current}]",
                                         )
                                     else:
-                                        self.asserURL(
+                                        self.assertURL(
                                             result,
                                             f"The URL in {key2}: {result} is not valid | URL: {current}",
                                         )
@@ -862,7 +862,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             msg=f"URL : [{current}]",
                                         )
                                     else:
-                                        self.asserURL(
+                                        self.assertURL(
                                             response.data[key2],
                                             f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
                                         )
@@ -916,7 +916,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             msg=f"URL : [{current}]",
                                         )
                                     else:
-                                        self.asserURL(
+                                        self.assertURL(
                                             response.data[key2],
                                             f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
                                         )
@@ -1349,7 +1349,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                         else:
-                                            self.asserURL(
+                                            self.assertURL(
                                                 result,
                                                 f"The URL in {key2}: {result} is not valid | URL: {current}",
                                             )
@@ -1373,7 +1373,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                         else:
-                                            self.asserURL(
+                                            self.assertURL(
                                                 result,
                                                 f"The URL in {key3}: {result} is not valid | URL: {current}",
                                             )
@@ -1419,7 +1419,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                         else:
-                                            self.asserURL(
+                                            self.assertURL(
                                                 response.data[key2],
                                                 f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
                                             )
@@ -1434,7 +1434,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                         else:
-                                            self.asserURL(
+                                            self.assertURL(
                                                 response.data[key3],
                                                 f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
                                             )
@@ -1499,7 +1499,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     msg=f"URL : [{current}]",
                                                 )
                                             else:
-                                                self.asserURL(
+                                                self.assertURL(
                                                     result,
                                                     f"The URL in {key3}: {result} is not valid | URL: {current}",
                                                 )
@@ -1566,7 +1566,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     msg=f"URL : [{current}]",
                                                 )
                                             else:
-                                                self.asserURL(
+                                                self.assertURL(
                                                     result,
                                                     f"The URL in {key3}: {result} is not valid | URL: {current}",
                                                 )
@@ -1632,7 +1632,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     msg=f"URL : [{current}]",
                                                 )
                                             else:
-                                                self.asserURL(
+                                                self.assertURL(
                                                     response.data[key3],
                                                     f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
                                                 )
@@ -1703,7 +1703,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     msg=f"URL : [{current}]",
                                                 )
                                             else:
-                                                self.asserURL(
+                                                self.assertURL(
                                                     response.data[key3],
                                                     f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
                                                 )

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -4,9 +4,6 @@ import os
 from rest_framework import status
 from webfront.tests.InterproRESTTestCase import InterproRESTTestCase
 from webfront.serializers.content_serializers import ModelContentSerializer
-from django.core.validators import URLValidator
-
-validateURL = URLValidator()
 
 api_test_map = {
     "entry": {
@@ -34,50 +31,52 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
+endpoints_with_url = ["entry"]
+
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
     def test_endpoints_independently(self):
         for endpoint in api_test_map:
-            current = "/api/" + endpoint
+            current = f"/api/{endpoint}"
             response = self.client.get(current)
             self.assertEqual(
-                response.status_code, status.HTTP_200_OK, "URL: [{}]".format(current)
+                response.status_code, status.HTTP_200_OK, f"URL: [{current}]"
             )
             self._check_counter_by_endpoint(
-                endpoint, response.data, "URL: [{}]".format(current)
+                endpoint, response.data, f"URL: [{current}]"
             )
 
             for db in api_test_map[endpoint]:
-                current = "/api/" + endpoint + "/" + db
+                current = f"/api/{endpoint}/{db}"
                 response_db = self.client.get(current)
                 self.assertEqual(
                     response_db.status_code,
                     status.HTTP_200_OK,
-                    "URL: [{}]".format(current),
+                    f"URL: [{current}]",
                 )
                 self.assertEqual(
                     len(response_db.data["results"]),
                     len(api_test_map[endpoint][db]),
-                    "URL: [{}]".format(current),
+                    f"URL: [{current}]",
                 )
                 self._check_is_list_of_metadata_objects(
-                    response_db.data["results"], "URL: [{}]".format(current)
+                    response_db.data["results"], f"URL: [{current}]"
                 )
 
                 for acc in api_test_map[endpoint][db]:
-                    current = "/api/" + endpoint + "/" + db + "/" + acc
+                    current = f"/api/{endpoint}/{db}/{acc}"
                     response_acc = self.client.get(current)
                     self.assertEqual(
                         response_acc.status_code,
                         status.HTTP_200_OK,
-                        "URL: [{}]".format(current),
+                        f"URL: [{current}]",
                     )
                     self._check_object_by_accesssion(
-                        response_acc.data, "URL: [{}]".format(current)
+                        response_acc.data, f"URL: [{current}]"
                     )
 
                     self._check_structure_and_chains(
-                        response_acc, endpoint, db, acc, "URL: [{}]".format(current)
+                        response_acc, endpoint, db, acc, f"URL: [{current}]"
                     )
 
     def test_endpoint_endpoint(self):
@@ -87,18 +86,18 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                     continue
 
                 # [endpoint]/[endpoint]
-                current = "/api/" + endpoint1 + "/" + endpoint2
+                current = f"/api/{endpoint1}/{endpoint2}"
                 response = self.client.get(current)
                 self.assertEqual(
                     response.status_code,
                     status.HTTP_200_OK,
-                    "URL : [{}]".format(current),
+                    f"URL : [{current}]",
                 )
                 self._check_counter_by_endpoint(
-                    endpoint1, response.data, "URL : [{}]".format(current)
+                    endpoint1, response.data, f"URL : [{current}]"
                 )
                 self._check_counter_by_endpoint(
-                    endpoint2, response.data, "URL : [{}]".format(current)
+                    endpoint2, response.data, f"URL : [{current}]"
                 )
 
     def test_db_endpoint(self):
@@ -108,21 +107,21 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                     continue
                 for db in api_test_map[endpoint1]:
                     # [endpoint]/[db]/[endpoint]
-                    current = "/api/" + endpoint1 + "/" + db + "/" + endpoint2
+                    current = f"/api/{endpoint1}/{db}/{endpoint2}"
                     response = self._get_in_debug_mode(current)
                     if response.status_code == status.HTTP_200_OK:
                         self.assertEqual(
                             response.status_code,
                             status.HTTP_200_OK,
-                            "URL : [{}]".format(current),
+                            f"URL : [{current}]",
                         )
                         self._check_is_list_of_metadata_objects(
-                            response.data["results"], "URL : [{}]".format(current)
+                            response.data["results"], f"URL : [{current}]"
                         )
                         self._check_is_list_of_objects_with_key(
                             response.data["results"],
                             plurals[endpoint2],
-                            "URL : [{}]".format(current),
+                            f"URL : [{current}]",
                         )
                     elif response.status_code != status.HTTP_204_NO_CONTENT:
                         self.assertEqual(
@@ -136,22 +135,22 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                     continue
                 for db in api_test_map[endpoint1]:
                     # [endpoint]/[endpoint]/[db]
-                    current = "/api/" + endpoint2 + "/" + endpoint1 + "/" + db + "/"
+                    current = f"/api/{endpoint2}/{endpoint1}/{db}/"
                     response = self._get_in_debug_mode(current)
                     if response.status_code == status.HTTP_200_OK:
                         self.assertEqual(
                             response.status_code,
                             status.HTTP_200_OK,
-                            "URL : [{}]".format(current),
+                            f"URL : [{current}]",
                         )
                         self._check_counter_by_endpoint(
-                            endpoint2, response.data, "URL : [{}]".format(current)
+                            endpoint2, response.data, f"URL : [{current}]"
                         )
                         self._check_count_overview_per_endpoints(
                             response.data,
                             plurals[endpoint1],
                             plurals[endpoint2],
-                            "URL : [{}]".format(current),
+                            f"URL : [{current}]",
                         )
                     elif response.status_code != status.HTTP_204_NO_CONTENT:
                         self.fail(
@@ -168,24 +167,22 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                 for db in api_test_map[endpoint1]:
                     for acc in api_test_map[endpoint1][db]:
                         # [endpoint]/[db]/[acc]/[endpoint]
-                        current = (
-                            "/api/" + endpoint1 + "/" + db + "/" + acc + "/" + endpoint2
-                        )
+                        current = f"/api/{endpoint1}/{db}/{acc}/{endpoint2}"
                         response = self._get_in_debug_mode(current)
                         if response.status_code == status.HTTP_200_OK:
                             self.assertEqual(
                                 response.status_code,
                                 status.HTTP_200_OK,
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                             self._check_object_by_accesssion(
-                                response.data, "URL : [{}]".format(current)
+                                response.data, f"URL : [{current}]"
                             )
                             self._check_counter_by_endpoint(
-                                endpoint2, response.data, "URL : [{}]".format(current)
+                                endpoint2, response.data, f"URL : [{current}]"
                             )
                             self._check_structure_and_chains(
-                                response, endpoint1, db, acc, "/" + endpoint2
+                                response, endpoint1, db, acc, f"/{endpoint2}"
                             )
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.assertEqual(
@@ -200,18 +197,16 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                 for db in api_test_map[endpoint1]:
                     for acc in api_test_map[endpoint1][db]:
                         # [endpoint]/[endpoint]/[db]/[acc]
-                        current = "/api/{}/{}/{}/{}/".format(
-                            endpoint2, endpoint1, db, acc
-                        )
+                        current = f"/api/{endpoint2}/{endpoint1}/{db}/{acc}/"
                         response = self._get_in_debug_mode(current)
                         if response.status_code == status.HTTP_200_OK:
                             self.assertEqual(
                                 response.status_code,
                                 status.HTTP_200_OK,
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                             self._check_counter_by_endpoint(
-                                endpoint2, response.data, "URL : [{}]".format(current)
+                                endpoint2, response.data, f"URL : [{current}]"
                             )
                             self._check_structure_chains_as_counter_filter(
                                 endpoint1,
@@ -233,21 +228,19 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                 for db in api_test_map[endpoint1]:
                     # [endpoint]/[db]/[endpoint]/[db]
                     for db2 in api_test_map[endpoint2]:
-                        current = (
-                            "/api/" + endpoint1 + "/" + db + "/" + endpoint2 + "/" + db2
-                        )
+                        current = f"/api/{endpoint1}/{db}/{endpoint2}/{db2}"
                         response = self._get_in_debug_mode(current)
                         if response.status_code == status.HTTP_200_OK:
                             self._check_is_list_of_metadata_objects(
-                                response.data["results"], "URL : [{}]".format(current)
+                                response.data["results"], f"URL : [{current}]"
                             )
-                            key2 = plurals[endpoint2] + "_url"
-                            if endpoint2 not in ["entry"]:
-                                key2 = endpoint2 + "_subset"
+                            key2 = f"{plurals[endpoint2]}_url"
+                            if endpoint2 not in endpoints_with_url:
+                                key2 = f"{endpoint2}_subset"
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     key2,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                             for result in [x[key2] for x in response.data["results"]]:
                                 if "_subset" in key2:
@@ -255,21 +248,19 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                         result,
                                         check_coordinates=endpoint2 != "taxonomy"
                                         and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
+                                        msg=f"URL : [{current}]",
                                     )
                                 else:
-                                    try:
-                                        validateURL(result)
-                                    except:
-                                        raise self.failureException(
-                                            f"The URL in {key2}: {result} is not valid | URL: {current}"
-                                        )
+                                    self.asserURL(
+                                        result,
+                                        f"The URL in {key2}: {result} is not valid | URL: {current}",
+                                    )
 
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.assertEqual(
                                 response.status_code,
                                 status.HTTP_204_NO_CONTENT,
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
 
     def test_db_acc(self):
@@ -281,15 +272,13 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                     for db2 in api_test_map[endpoint2]:
                         for acc in api_test_map[endpoint1][db]:
                             # [endpoint]/[db]/[endpoint]/[db]/[acc]
-                            current = "/api/{}/{}/{}/{}/{}/".format(
-                                endpoint2, db2, endpoint1, db, acc
-                            )
+                            current = f"/api/{endpoint2}/{db2}/{endpoint1}/{db}/{acc}/"
                             response = self._get_in_debug_mode(current)
                             if response.status_code == status.HTTP_200_OK:
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_200_OK,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_is_list_of_metadata_objects(
                                     response.data["results"]
@@ -302,13 +291,13 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                         result,
                                         check_coordinates=endpoint1 != "taxonomy"
                                         and endpoint1 != "proteome",
-                                        msg="URL : [{}]".format(current),
+                                        msg=f"URL : [{current}]",
                                     )
                                 self._check_structure_chains_as_filter(
                                     endpoint1,
                                     db,
                                     acc,
-                                    endpoint2 + "/" + db2,
+                                    f"{endpoint2}/{db2}",
                                     "",
                                     plurals[endpoint1],
                                 )
@@ -316,7 +305,7 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_204_NO_CONTENT,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
 
     def test_acc_db(self):
@@ -334,19 +323,19 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_200_OK,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_object_by_accesssion(
-                                    response.data, "URL : [{}]".format(current)
+                                    response.data, f"URL : [{current}]"
                                 )
-                                key = plurals[endpoint2] + "_url"
-                                if endpoint2 not in ["entry"]:
-                                    key = endpoint2 + "_subset"
+                                key = f"{plurals[endpoint2]}_url"
+                                if endpoint2 not in endpoints_with_url:
+                                    key = f"{endpoint2}_subset"
                                     self._check_list_of_matches(
                                         response.data[key],
                                         check_coordinates=endpoint2 != "taxonomy"
                                         and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
+                                        msg=f"URL : [{current}]",
                                     )
                                     self._check_structure_and_chains(
                                         response,
@@ -355,16 +344,13 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                         acc,
                                         f"/{endpoint2}/{db2}",
                                         key,
-                                        msg="URL : [{}]".format(current),
+                                        msg=f"URL : [{current}]",
                                     )
                                 else:
-                                    try:
-                                        validateURL(response.data[key])
-                                    except:
-                                        raise self.failureException(
-                                            f"The URL in {key}: {response.data[key]} is not valid | URL: {current}"
-                                        )
-
+                                    self.asserURL(
+                                        response.data[key],
+                                        f"The URL in {key}: {response.data[key]} is not valid | URL: {current}",
+                                    )
                             elif response.status_code != status.HTTP_204_NO_CONTENT:
                                 self.assertEqual(
                                     response.status_code, status.HTTP_204_NO_CONTENT
@@ -388,28 +374,28 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_object_by_accesssion(response.data)
                                     self._check_list_of_matches(
                                         response.data[plurals[endpoint2]],
                                         check_coordinates=endpoint2 != "taxonomy"
                                         and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
+                                        msg=f"URL : [{current}]",
                                     )
                                     self._check_structure_and_chains(
                                         response,
                                         endpoint1,
                                         db,
                                         acc,
-                                        "/" + endpoint2 + "/" + db2 + "/" + acc2,
+                                        f"/{endpoint2}/{db2}/{acc2}",
                                         plurals[endpoint2],
                                     )
                                     self._check_structure_chains_as_filter(
                                         endpoint2,
                                         db2,
                                         acc2,
-                                        endpoint1 + "/" + db + "/" + acc,
+                                        f"{endpoint1}/{db}/{acc}",
                                         "",
                                         plurals[endpoint2],
                                     )
@@ -417,7 +403,7 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_204_NO_CONTENT,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
 
 
@@ -436,21 +422,21 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         continue
 
                     # [endpoint]/[endpoint]
-                    current = "/api/" + endpoint1 + "/" + endpoint2 + "/" + endpoint3
+                    current = f"/api/{endpoint1}/{endpoint2}/{endpoint3}"
                     response = self.client.get(current)
                     self.assertEqual(
                         response.status_code,
                         status.HTTP_200_OK,
-                        "URL : [{}]".format(current),
+                        f"URL : [{current}]",
                     )
                     self._check_counter_by_endpoint(
-                        endpoint1, response.data, "URL : [{}]".format(current)
+                        endpoint1, response.data, f"URL : [{current}]"
                     )
                     self._check_counter_by_endpoint(
-                        endpoint2, response.data, "URL : [{}]".format(current)
+                        endpoint2, response.data, f"URL : [{current}]"
                     )
                     self._check_counter_by_endpoint(
-                        endpoint3, response.data, "URL : [{}]".format(current)
+                        endpoint3, response.data, f"URL : [{current}]"
                     )
 
     def test_endpoint_db_endpoint(self):
@@ -463,33 +449,20 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         continue
                     for db1 in api_test_map[endpoint1]:
                         # [endpoint]/[endpoint]/[db]/[endpoint]
-                        current = (
-                            "/api/"
-                            + endpoint2
-                            + "/"
-                            + endpoint1
-                            + "/"
-                            + db1
-                            + "/"
-                            + endpoint3
-                        )
+                        current = f"/api/{endpoint2}/{endpoint1}/{db1}/{endpoint3}"
                         response = self._get_in_debug_mode(current)
                         if response.status_code == status.HTTP_200_OK:
                             self.assertEqual(
                                 response.status_code,
                                 status.HTTP_200_OK,
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                             self._check_counter_by_endpoint(
-                                endpoint2, response.data, "URL : [{}]".format(current)
+                                endpoint2, response.data, f"URL : [{current}]"
                             )
                             self._check_counter_by_endpoint(
-                                endpoint3, response.data, "URL : [{}]".format(current)
+                                endpoint3, response.data, f"URL : [{current}]"
                             )
-                            # self._check_count_overview_per_endpoints(response.data,
-                            #                                          plurals[endpoint1],
-                            #                                          plurals[endpoint2],
-                            #                                          "URL : [{}]".format(current))
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.assertEqual(
                                 response.status_code, status.HTTP_204_NO_CONTENT
@@ -505,30 +478,21 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         continue
                     for db1 in api_test_map[endpoint1]:
                         # [endpoint]/[db]/[endpoint]/[endpoint]
-                        current = (
-                            "/api/"
-                            + endpoint1
-                            + "/"
-                            + db1
-                            + "/"
-                            + endpoint2
-                            + "/"
-                            + endpoint3
-                        )
+                        current = f"/api/{endpoint1}/{db1}/{endpoint2}/{endpoint3}"
                         response = self._get_in_debug_mode(current)
                         if response.status_code == status.HTTP_200_OK:
                             self.assertEqual(
                                 response.status_code,
                                 status.HTTP_200_OK,
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                             self._check_is_list_of_metadata_objects(
-                                response.data["results"], "URL : [{}]".format(current)
+                                response.data["results"], f"URL : [{current}]"
                             )
                             self._check_is_list_of_objects_with_key(
                                 response.data["results"],
                                 plurals[endpoint2],
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.assertEqual(
@@ -547,44 +511,30 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for acc in api_test_map[endpoint1][db1]:
                             # [endpoint]/[endpoint]/[endpoint]/[db]/[acc]
                             current = (
-                                "/api/"
-                                + endpoint2
-                                + "/"
-                                + endpoint3
-                                + "/"
-                                + endpoint1
-                                + "/"
-                                + db1
-                                + "/"
-                                + acc
-                                + "/"
+                                f"/api/{endpoint2}/{endpoint3}/{endpoint1}/{db1}/{acc}/"
                             )
                             response = self._get_in_debug_mode(current)
                             if response.status_code == status.HTTP_200_OK:
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_200_OK,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint2,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint3,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
-                                # self._check_count_overview_per_endpoints(response.data,
-                                #                                          plurals[endpoint1],
-                                #                                          plurals[endpoint2],
-                                #                                          "URL : [{}]".format(current))
                                 self._check_structure_chains_as_counter_filter(
                                     endpoint1,
                                     db1,
                                     acc,
-                                    endpoint2 + "/" + endpoint3,
+                                    f"{endpoint2}/{endpoint3}",
                                     "",
                                     plurals[endpoint1],
                                     plurals[endpoint2],
@@ -606,35 +556,25 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         continue
                     for db1 in api_test_map[endpoint1]:
                         # [endpoint]/[endpoint]/[endpoint]/[db]
-                        current = (
-                            "/api/"
-                            + endpoint2
-                            + "/"
-                            + endpoint3
-                            + "/"
-                            + endpoint1
-                            + "/"
-                            + db1
-                            + "/"
-                        )
+                        current = f"/api/{endpoint2}/{endpoint3}/{endpoint1}/{db1}/"
                         response = self._get_in_debug_mode(current)
                         if response.status_code == status.HTTP_200_OK:
                             self.assertEqual(
                                 response.status_code,
                                 status.HTTP_200_OK,
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                             self._check_counter_by_endpoint(
-                                endpoint2, response.data, "URL : [{}]".format(current)
+                                endpoint2, response.data, f"URL : [{current}]"
                             )
                             self._check_counter_by_endpoint(
-                                endpoint3, response.data, "URL : [{}]".format(current)
+                                endpoint3, response.data, f"URL : [{current}]"
                             )
                             self._check_count_overview_per_endpoints(
                                 response.data,
                                 plurals[endpoint1],
                                 plurals[endpoint2],
-                                "URL : [{}]".format(current),
+                                f"URL : [{current}]",
                             )
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.fail(
@@ -655,44 +595,31 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for acc in api_test_map[endpoint1][db1]:
                             # [endpoint]/[endpoint]/[db]/[acc]/[endpoint]
                             current = (
-                                "/api/"
-                                + endpoint2
-                                + "/"
-                                + endpoint1
-                                + "/"
-                                + db1
-                                + "/"
-                                + acc
-                                + "/"
-                                + endpoint3
+                                f"/api/{endpoint2}/{endpoint1}/{db1}/{acc}/{endpoint3}"
                             )
                             response = self._get_in_debug_mode(current)
                             if response.status_code == status.HTTP_200_OK:
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_200_OK,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint2,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint3,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
-                                # self._check_count_overview_per_endpoints(response.data,
-                                #                                          plurals[endpoint1],
-                                #                                          plurals[endpoint2],
-                                #                                          "URL : [{}]".format(current))
                                 self._check_structure_chains_as_counter_filter(
                                     endpoint1,
                                     db1,
                                     acc,
                                     endpoint2,
-                                    "/" + endpoint3,
+                                    f"/{endpoint3}",
                                     plurals[endpoint1],
                                     plurals[endpoint2],
                                 )
@@ -715,16 +642,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for acc in api_test_map[endpoint1][db1]:
                             # [endpoint]/[db]/[acc]/[endpoint]/[endpoint]
                             current = (
-                                "/api/"
-                                + endpoint1
-                                + "/"
-                                + db1
-                                + "/"
-                                + acc
-                                + "/"
-                                + endpoint2
-                                + "/"
-                                + endpoint3
+                                f"/api/{endpoint1}/{db1}/{acc}/{endpoint2}/{endpoint3}"
                             )
                             response = self._get_in_debug_mode(current)
 
@@ -732,27 +650,27 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_200_OK,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_object_by_accesssion(
-                                    response.data, "URL : [{}]".format(current)
+                                    response.data, f"URL : [{current}]"
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint2,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint3,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_structure_and_chains(
                                     response,
                                     endpoint1,
                                     db1,
                                     acc,
-                                    "/" + endpoint2 + "/" + endpoint3,
+                                    f"/{endpoint2}/{endpoint3}",
                                 )
                             elif response.status_code != status.HTTP_204_NO_CONTENT:
                                 self.assertEqual(
@@ -771,42 +689,42 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         # [endpoint]/[db]/[endpoint]/[db]/[endpoint]
                         for db2 in api_test_map[endpoint2]:
                             current = (
-                                f"/api/"
-                                + endpoint1
-                                + "/"
-                                + db1
-                                + "/"
-                                + endpoint2
-                                + "/"
-                                + db2
-                                + "/"
-                                + endpoint3
+                                f"/api/{endpoint1}/{db1}/{endpoint2}/{db2}/{endpoint3}"
                             )
                             response = self._get_in_debug_mode(current)
                             if response.status_code == status.HTTP_200_OK:
-                                key = plurals[endpoint2] + "_url"
                                 self._check_is_list_of_metadata_objects(
                                     response.data["results"],
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
+
+                                key = f"{plurals[endpoint2]}_url"
+                                if endpoint2 not in endpoints_with_url:
+                                    key = f"{endpoint2}_subset"
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     key,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 for result in [
                                     x[key] for x in response.data["results"]
                                 ]:
-                                    self._check_list_of_matches(
-                                        result,
-                                        check_coordinates=endpoint2 != "taxonomy"
-                                        and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
-                                    )
+                                    if "_subset" in key:
+                                        self._check_list_of_matches(
+                                            result,
+                                            check_coordinates=endpoint2 != "taxonomy"
+                                            and endpoint2 != "proteome",
+                                            msg=f"URL : [{current}]",
+                                        )
+                                    else:
+                                        self.asserURL(
+                                            result,
+                                            f"The URL in {key}: {result} is not valid | URL: {current}",
+                                        )
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     plurals[endpoint3],
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                             elif response.status_code != status.HTTP_204_NO_CONTENT:
                                 self.assertEqual(
@@ -825,42 +743,41 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             # [endpoint]/[db]/[endpoint]/[endpoint]/[db]
                             current = (
-                                "/api/"
-                                + endpoint1
-                                + "/"
-                                + db1
-                                + "/"
-                                + endpoint3
-                                + "/"
-                                + endpoint2
-                                + "/"
-                                + db2
+                                f"/api/{endpoint1}/{db1}/{endpoint3}/{endpoint2}/{db2}"
                             )
                             response = self._get_in_debug_mode(current)
                             if response.status_code == status.HTTP_200_OK:
-                                key2 = plurals[endpoint2] + "_url"
                                 self._check_is_list_of_metadata_objects(
                                     response.data["results"],
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
+                                key2 = f"{plurals[endpoint2]}_url"
+                                if endpoint2 not in endpoints_with_url:
+                                    key2 = f"{endpoint2}_subset"
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     key2,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 for result in [
                                     x[key2] for x in response.data["results"]
                                 ]:
-                                    self._check_list_of_matches(
-                                        result,
-                                        check_coordinates=endpoint2 != "taxonomy"
-                                        and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
-                                    )
+                                    if "_subset" in key2:
+                                        self._check_list_of_matches(
+                                            result,
+                                            check_coordinates=endpoint2 != "taxonomy"
+                                            and endpoint2 != "proteome",
+                                            msg=f"URL : [{current}]",
+                                        )
+                                    else:
+                                        self.asserURL(
+                                            result,
+                                            f"The URL in {key2}: {result} is not valid | URL: {current}",
+                                        )
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     plurals[endpoint3],
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                             elif response.status_code != status.HTTP_204_NO_CONTENT:
                                 self.assertEqual(
@@ -879,40 +796,31 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             # [endpoint]/[endpoint]/[db]/[endpoint]/[db]
                             current = (
-                                "/api/"
-                                + endpoint3
-                                + "/"
-                                + endpoint2
-                                + "/"
-                                + db2
-                                + "/"
-                                + endpoint1
-                                + "/"
-                                + db1
+                                f"/api/{endpoint3}/{endpoint2}/{db2}/{endpoint1}/{db1}"
                             )
                             response = self._get_in_debug_mode(current)
                             if response.status_code == status.HTTP_200_OK:
                                 self.assertEqual(
                                     response.status_code,
                                     status.HTTP_200_OK,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_counter_by_endpoint(
                                     endpoint3,
                                     response.data,
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_count_overview_per_endpoints(
                                     response.data,
                                     plurals[endpoint2],
                                     plurals[endpoint3],
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                                 self._check_count_overview_per_endpoints(
                                     response.data,
                                     plurals[endpoint1],
                                     plurals[endpoint3],
-                                    "URL : [{}]".format(current),
+                                    f"URL : [{current}]",
                                 )
                             elif response.status_code != status.HTTP_204_NO_CONTENT:
                                 self.fail(
@@ -933,48 +841,42 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for acc1 in api_test_map[endpoint1][db1]:
                                 # [endpoint]/[db]/[acc]/[endpoint]/[db]/[endpoint]
-                                current = (
-                                    "/api/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + acc1
-                                    + "/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                    + "/"
-                                    + endpoint3
-                                )
+                                current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{endpoint3}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
-                                    key2 = plurals[endpoint2] + "_url"
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_object_by_accesssion(
-                                        response.data, "URL : [{}]".format(current)
+                                        response.data, f"URL : [{current}]"
                                     )
-                                    self._check_list_of_matches(
-                                        response.data[key2],
-                                        check_coordinates=endpoint2 != "taxonomy"
-                                        and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
-                                    )
+                                    key2 = f"{plurals[endpoint2]}_url"
+                                    if endpoint2 not in endpoints_with_url:
+                                        key2 = f"{endpoint2}_subset"
+                                        self._check_list_of_matches(
+                                            response.data[key2],
+                                            check_coordinates=endpoint2 != "taxonomy"
+                                            and endpoint2 != "proteome",
+                                            msg=f"URL : [{current}]",
+                                        )
+                                    else:
+                                        self.asserURL(
+                                            response.data[key2],
+                                            f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
+                                        )
                                     self._check_counter_by_endpoint(
                                         endpoint3,
                                         response.data,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_structure_and_chains(
                                         response,
                                         endpoint1,
                                         db1,
                                         acc1,
-                                        "/" + endpoint2 + "/" + db2 + "/" + endpoint3,
+                                        f"/{endpoint2}/{db2}/{endpoint3}",
                                     )
                                 elif response.status_code != status.HTTP_204_NO_CONTENT:
                                     self.assertEqual(
@@ -993,48 +895,42 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for acc1 in api_test_map[endpoint1][db1]:
                                 # [endpoint]/[db]/[acc]/[endpoint]/[endpoint]/[db]
-                                current = (
-                                    "/api/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + acc1
-                                    + "/"
-                                    + endpoint3
-                                    + "/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                )
+                                current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint3}/{endpoint2}/{db2}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
-                                    key2 = plurals[endpoint2] + "_url"
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_object_by_accesssion(
-                                        response.data, "URL : [{}]".format(current)
+                                        response.data, f"URL : [{current}]"
                                     )
-                                    self._check_list_of_matches(
-                                        response.data[key2],
-                                        check_coordinates=endpoint2 != "taxonomy"
-                                        and endpoint2 != "proteome",
-                                        msg="URL : [{}]".format(current),
-                                    )
+                                    key2 = f"{plurals[endpoint2]}_url"
+                                    if endpoint2 not in endpoints_with_url:
+                                        key2 = f"{endpoint2}_subset"
+                                        self._check_list_of_matches(
+                                            response.data[key2],
+                                            check_coordinates=endpoint2 != "taxonomy"
+                                            and endpoint2 != "proteome",
+                                            msg=f"URL : [{current}]",
+                                        )
+                                    else:
+                                        self.asserURL(
+                                            response.data[key2],
+                                            f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
+                                        )
                                     self._check_counter_by_endpoint(
                                         endpoint3,
                                         response.data,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_structure_and_chains(
                                         response,
                                         endpoint1,
                                         db1,
                                         acc1,
-                                        "/" + endpoint3 + "/" + endpoint2 + "/" + db2,
+                                        f"/{endpoint3}/{endpoint2}/{db2}",
                                     )
                                 elif response.status_code != status.HTTP_204_NO_CONTENT:
                                     self.assertEqual(
@@ -1053,26 +949,13 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for acc1 in api_test_map[endpoint1][db1]:
                                 # /[endpoint]/[db]/[endpoint]/[db]/[acc]/[endpoint]
-                                current = (
-                                    "/api/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                    + "/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + acc1
-                                    + "/"
-                                    + endpoint3
-                                )
+                                current = f"/api/{endpoint2}/{db2}/{endpoint1}/{db1}/{acc1}/{endpoint3}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_is_list_of_metadata_objects(
                                         response.data["results"]
@@ -1085,19 +968,19 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             result,
                                             check_coordinates=endpoint1 != "taxonomy"
                                             and endpoint1 != "proteome",
-                                            msg="URL : [{}]".format(current),
+                                            msg=f"URL : [{current}]",
                                         )
                                     self._check_is_list_of_objects_with_key(
                                         response.data["results"],
                                         plurals[endpoint3],
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_structure_chains_as_filter(
                                         endpoint1,
                                         db1,
                                         acc1,
-                                        endpoint2 + "/" + db2,
-                                        "/" + endpoint3,
+                                        f"{endpoint2}/{db2}",
+                                        f"/{endpoint3}",
                                         plurals[endpoint1],
                                     )
                                 elif response.status_code != status.HTTP_204_NO_CONTENT:
@@ -1117,26 +1000,13 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for acc1 in api_test_map[endpoint1][db1]:
                                 # /[endpoint]/[db]/[endpoint]/[endpoint]/[db]/[acc]
-                                current = (
-                                    "/api/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                    + "/"
-                                    + endpoint3
-                                    + "/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + acc1
-                                )
+                                current = f"/api/{endpoint2}/{db2}/{endpoint3}/{endpoint1}/{db1}/{acc1}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_is_list_of_metadata_objects(
                                         response.data["results"]
@@ -1149,18 +1019,18 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             result,
                                             check_coordinates=endpoint1 != "taxonomy"
                                             and endpoint1 != "proteome",
-                                            msg="URL : [{}]".format(current),
+                                            msg=f"URL : [{current}]",
                                         )
                                     self._check_is_list_of_objects_with_key(
                                         response.data["results"],
                                         plurals[endpoint3],
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_structure_chains_as_filter(
                                         endpoint1,
                                         db1,
                                         acc1,
-                                        endpoint2 + "/" + db2 + "/" + endpoint3,
+                                        f"{endpoint2}/{db2}/{endpoint3}",
                                         "",
                                         plurals[endpoint1],
                                     )
@@ -1181,48 +1051,31 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for acc1 in api_test_map[endpoint1][db1]:
                                 # /[endpoint]/[endpoint]/[db]/[endpoint]/[db]/[acc]
-                                current = (
-                                    "/api/"
-                                    + endpoint3
-                                    + "/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                    + "/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + acc1
-                                )
+                                current = f"/api/{endpoint3}/{endpoint2}/{db2}/{endpoint1}/{db1}/{acc1}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_counter_by_endpoint(
                                         endpoint3,
                                         response.data,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_count_overview_per_endpoints(
                                         response.data,
                                         plurals[endpoint2],
                                         plurals[endpoint3],
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
-                                    # self._check_count_overview_per_endpoints(response.data,
-                                    #                                          plurals[endpoint1],
-                                    #                                          plurals[endpoint3],
-                                    #                                          "URL : [{}]".format(current))
 
                                     self._check_structure_chains_as_counter_filter(
                                         endpoint1,
                                         db1,
                                         acc1,
-                                        endpoint3 + "/" + endpoint2 + "/" + db2 + "/",
+                                        f"{endpoint3}/{endpoint2}/{db2}/",
                                         "",
                                         plurals[endpoint1],
                                         plurals[endpoint3],
@@ -1246,49 +1099,32 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for acc1 in api_test_map[endpoint1][db1]:
                                 # /[endpoint]/[endpoint]/[db]/[acc]/[endpoint]/[db]
-                                current = (
-                                    "/api/"
-                                    + endpoint3
-                                    + "/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + acc1
-                                    + "/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                )
+                                current = f"/api/{endpoint3}/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_200_OK,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_counter_by_endpoint(
                                         endpoint3,
                                         response.data,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     self._check_count_overview_per_endpoints(
                                         response.data,
                                         plurals[endpoint2],
                                         plurals[endpoint3],
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
-                                    # self._check_count_overview_per_endpoints(response.data,
-                                    #                                          plurals[endpoint1],
-                                    #                                          plurals[endpoint3],
-                                    #                                          "URL : [{}]".format(current))
 
                                     self._check_structure_chains_as_counter_filter(
                                         endpoint1,
                                         db1,
                                         acc1,
                                         endpoint3,
-                                        "/" + endpoint2 + "/" + db2,
+                                        f"/{endpoint2}/{db2}",
                                         plurals[endpoint1],
                                         plurals[endpoint3],
                                     )
@@ -1313,41 +1149,26 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                             for acc1 in api_test_map[endpoint1][db1]:
                                 for acc2 in api_test_map[endpoint2][db2]:
                                     # [endpoint]/[db]/[acc]/[endpoint]/[db]/[acc]/[endpoint]
-                                    current = (
-                                        "/api/"
-                                        + endpoint1
-                                        + "/"
-                                        + db1
-                                        + "/"
-                                        + acc1
-                                        + "/"
-                                        + endpoint2
-                                        + "/"
-                                        + db2
-                                        + "/"
-                                        + acc2
-                                        + "/"
-                                        + endpoint3
-                                    )
+                                    current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{acc2}/{endpoint3}"
                                     tested.append(current)
                                     response = self._get_in_debug_mode(current)
                                     if response.status_code == status.HTTP_200_OK:
                                         self.assertEqual(
                                             response.status_code,
                                             status.HTTP_200_OK,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
                                         self._check_object_by_accesssion(response.data)
                                         self._check_list_of_matches(
                                             response.data[plurals[endpoint2]],
                                             check_coordinates=endpoint2 != "taxonomy"
                                             and endpoint2 != "proteome",
-                                            msg="URL : [{}]".format(current),
+                                            msg=f"URL : [{current}]",
                                         )
                                         self._check_counter_by_endpoint(
                                             endpoint3,
                                             response.data,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
 
                                         tested += self._check_structure_and_chains(
@@ -1355,14 +1176,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             endpoint1,
                                             db1,
                                             acc1,
-                                            "/"
-                                            + endpoint2
-                                            + "/"
-                                            + db2
-                                            + "/"
-                                            + acc2
-                                            + "/"
-                                            + endpoint3,
+                                            f"/{endpoint2}/{db2}/{acc2}/{endpoint3}",
                                         )
 
                                         tested += (
@@ -1370,8 +1184,8 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 endpoint2,
                                                 db2,
                                                 acc2,
-                                                endpoint1 + "/" + db1 + "/" + acc1,
-                                                "/" + endpoint3,
+                                                f"{endpoint1}/{db1}/{acc1}",
+                                                f"/{endpoint3}",
                                             )
                                         )
 
@@ -1397,40 +1211,25 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                             for acc1 in api_test_map[endpoint1][db1]:
                                 for acc2 in api_test_map[endpoint2][db2]:
                                     # [endpoint]/[db]/[acc]/[endpoint]/[endpoint]/[db]/[acc]
-                                    current = (
-                                        "/api/"
-                                        + endpoint1
-                                        + "/"
-                                        + db1
-                                        + "/"
-                                        + acc1
-                                        + "/"
-                                        + endpoint3
-                                        + "/"
-                                        + endpoint2
-                                        + "/"
-                                        + db2
-                                        + "/"
-                                        + acc2
-                                    )
+                                    current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint3}/{endpoint2}/{db2}/{acc2}"
                                     response = self._get_in_debug_mode(current)
                                     if response.status_code == status.HTTP_200_OK:
                                         self.assertEqual(
                                             response.status_code,
                                             status.HTTP_200_OK,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
                                         self._check_object_by_accesssion(response.data)
                                         self._check_list_of_matches(
                                             response.data[plurals[endpoint2]],
                                             check_coordinates=endpoint2 != "taxonomy"
                                             and endpoint2 != "proteome",
-                                            msg="URL : [{}]".format(current),
+                                            msg=f"URL : [{current}]",
                                         )
                                         self._check_counter_by_endpoint(
                                             endpoint3,
                                             response.data,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
 
                                         self._check_structure_and_chains(
@@ -1438,27 +1237,14 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             endpoint1,
                                             db1,
                                             acc1,
-                                            "/"
-                                            + endpoint3
-                                            + "/"
-                                            + endpoint2
-                                            + "/"
-                                            + db2
-                                            + "/"
-                                            + acc2,
+                                            f"/{endpoint3}/{endpoint2}/{db2}/{acc2}",
                                         )
 
                                         self._check_structure_chains_as_filter(
                                             endpoint2,
                                             db2,
                                             acc2,
-                                            endpoint1
-                                            + "/"
-                                            + db1
-                                            + "/"
-                                            + acc1
-                                            + "/"
-                                            + endpoint3,
+                                            f"{endpoint1}/{db1}/{acc1}/{endpoint3}",
                                             "",
                                         )
                                     elif (
@@ -1483,48 +1269,26 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                             for acc1 in api_test_map[endpoint1][db1]:
                                 for acc2 in api_test_map[endpoint2][db2]:
                                     # /[endpoint]/[endpoint]/[db]/[acc]/[endpoint]/[db]/[acc]
-                                    current = (
-                                        "/api/"
-                                        + endpoint3
-                                        + "/"
-                                        + endpoint1
-                                        + "/"
-                                        + db1
-                                        + "/"
-                                        + acc1
-                                        + "/"
-                                        + endpoint2
-                                        + "/"
-                                        + db2
-                                        + "/"
-                                        + acc2
-                                    )
+                                    current = f"/api/{endpoint3}/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{acc2}"
+
                                     response = self._get_in_debug_mode(current)
                                     if response.status_code == status.HTTP_200_OK:
                                         self.assertEqual(
                                             response.status_code,
                                             status.HTTP_200_OK,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
                                         self._check_counter_by_endpoint(
                                             endpoint3,
                                             response.data,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
-                                        # self._check_count_overview_per_endpoints(response.data,
-                                        #                                          plurals[endpoint2],
-                                        #                                          plurals[endpoint3],
-                                        #                                          "URL : [{}]".format(current))
-                                        # self._check_count_overview_per_endpoints(response.data,
-                                        #                                          plurals[endpoint1],
-                                        #                                          plurals[endpoint3],
-                                        #                                          "URL : [{}]".format(current))
                                         self._check_structure_chains_as_counter_filter(
                                             endpoint1,
                                             db1,
                                             acc1,
                                             endpoint3,
-                                            "/" + endpoint2 + "/" + db2 + "/" + acc2,
+                                            f"/{endpoint2}/{db2}/{acc2}",
                                             plurals[endpoint1],
                                             plurals[endpoint3],
                                         )
@@ -1532,13 +1296,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             endpoint2,
                                             db2,
                                             acc2,
-                                            endpoint3
-                                            + "/"
-                                            + endpoint1
-                                            + "/"
-                                            + db1
-                                            + "/"
-                                            + acc1,
+                                            f"{endpoint3}/{endpoint1}/{db1}/{acc1}",
                                             "",
                                             plurals[endpoint2],
                                             plurals[endpoint3],
@@ -1564,61 +1322,66 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                     for db1 in api_test_map[endpoint1]:
                         for db2 in api_test_map[endpoint2]:
                             for db3 in api_test_map[endpoint3]:
-                                current = (
-                                    "/api/"
-                                    + endpoint1
-                                    + "/"
-                                    + db1
-                                    + "/"
-                                    + endpoint2
-                                    + "/"
-                                    + db2
-                                    + "/"
-                                    + endpoint3
-                                    + "/"
-                                    + db3
-                                )
+                                current = f"/api/{endpoint1}/{db1}/{endpoint2}/{db2}/{endpoint3}/{db3}"
                                 response = self._get_in_debug_mode(current)
                                 if response.status_code == status.HTTP_200_OK:
-                                    key2 = plurals[endpoint2] + "_url"
-                                    key3 = plurals[endpoint3] + "_url"
                                     self._check_is_list_of_metadata_objects(
                                         response.data["results"],
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
+                                    key2 = f"{plurals[endpoint2]}_url"
+                                    if endpoint2 not in endpoints_with_url:
+                                        key2 = f"{endpoint2}_subset"
                                     self._check_is_list_of_objects_with_key(
                                         response.data["results"],
                                         key2,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     for result in [
                                         x[key2] for x in response.data["results"]
                                     ]:
-                                        self._check_list_of_matches(
-                                            result,
-                                            check_coordinates=endpoint2 != "taxonomy"
-                                            and endpoint2 != "proteome",
-                                            msg="URL : [{}]".format(current),
-                                        )
+                                        if "_subset" in key2:
+                                            self._check_list_of_matches(
+                                                result,
+                                                check_coordinates=endpoint2
+                                                != "taxonomy"
+                                                and endpoint2 != "proteome",
+                                                msg=f"URL : [{current}]",
+                                            )
+                                        else:
+                                            self.asserURL(
+                                                result,
+                                                f"The URL in {key2}: {result} is not valid | URL: {current}",
+                                            )
+                                    key3 = f"{plurals[endpoint3]}_url"
+                                    if endpoint3 not in endpoints_with_url:
+                                        key3 = f"{endpoint3}_subset"
                                     self._check_is_list_of_objects_with_key(
                                         response.data["results"],
                                         key3,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
                                     for result in [
                                         x[key3] for x in response.data["results"]
                                     ]:
-                                        self._check_list_of_matches(
-                                            result,
-                                            check_coordinates=endpoint3 != "taxonomy"
-                                            and endpoint3 != "proteome",
-                                            msg="URL : [{}]".format(current),
-                                        )
+                                        if "_subset" in key3:
+                                            self._check_list_of_matches(
+                                                result,
+                                                check_coordinates=endpoint3
+                                                != "taxonomy"
+                                                and endpoint3 != "proteome",
+                                                msg=f"URL : [{current}]",
+                                            )
+                                        else:
+                                            self.asserURL(
+                                                result,
+                                                f"The URL in {key3}: {result} is not valid | URL: {current}",
+                                            )
                                 elif response.status_code != status.HTTP_204_NO_CONTENT:
                                     self.assertEqual(
                                         response.status_code,
                                         status.HTTP_204_NO_CONTENT,
-                                        "URL : [{}]".format(current),
+                                        f"URL : [{current}]",
                                     )
 
     def test_acc_db_db(self):
@@ -1634,59 +1397,53 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                             for db3 in api_test_map[endpoint3]:
                                 for acc1 in api_test_map[endpoint1][db1]:
                                     # [endpoint]/[db]/[acc]/[endpoint]/[db]/[endpoint]/[db]
-                                    current = (
-                                        "/api/"
-                                        + endpoint1
-                                        + "/"
-                                        + db1
-                                        + "/"
-                                        + acc1
-                                        + "/"
-                                        + endpoint2
-                                        + "/"
-                                        + db2
-                                        + "/"
-                                        + endpoint3
-                                        + "/"
-                                        + db3
-                                    )
+                                    current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{endpoint3}/{db3}"
                                     response = self._get_in_debug_mode(current)
                                     if response.status_code == status.HTTP_200_OK:
-                                        key2 = plurals[endpoint2] + "_url"
-                                        key3 = plurals[endpoint3] + "_url"
                                         self.assertEqual(
                                             response.status_code,
                                             status.HTTP_200_OK,
-                                            "URL : [{}]".format(current),
+                                            f"URL : [{current}]",
                                         )
                                         self._check_object_by_accesssion(
-                                            response.data, "URL : [{}]".format(current)
+                                            response.data, f"URL : [{current}]"
                                         )
-                                        self._check_list_of_matches(
-                                            response.data[key2],
-                                            check_coordinates=endpoint2 != "taxonomy"
-                                            and endpoint2 != "proteome",
-                                            msg="URL : [{}]".format(current),
-                                        )
-                                        self._check_list_of_matches(
-                                            response.data[key3],
-                                            check_coordinates=endpoint3 != "taxonomy"
-                                            and endpoint3 != "proteome",
-                                            msg="URL : [{}]".format(current),
-                                        )
+                                        key2 = f"{plurals[endpoint2]}_url"
+                                        if endpoint2 not in endpoints_with_url:
+                                            key2 = f"{endpoint2}_subset"
+                                            self._check_list_of_matches(
+                                                response.data[key2],
+                                                check_coordinates=endpoint2
+                                                != "taxonomy"
+                                                and endpoint2 != "proteome",
+                                                msg=f"URL : [{current}]",
+                                            )
+                                        else:
+                                            self.asserURL(
+                                                response.data[key2],
+                                                f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
+                                            )
+                                        key3 = f"{plurals[endpoint3]}_url"
+                                        if endpoint3 not in endpoints_with_url:
+                                            key3 = f"{endpoint3}_subset"
+                                            self._check_list_of_matches(
+                                                response.data[key3],
+                                                check_coordinates=endpoint3
+                                                != "taxonomy"
+                                                and endpoint3 != "proteome",
+                                                msg=f"URL : [{current}]",
+                                            )
+                                        else:
+                                            self.asserURL(
+                                                response.data[key3],
+                                                f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
+                                            )
                                         self._check_structure_and_chains(
                                             response,
                                             endpoint1,
                                             db1,
                                             acc1,
-                                            "/"
-                                            + endpoint2
-                                            + "/"
-                                            + db2
-                                            + "/"
-                                            + endpoint3
-                                            + "/"
-                                            + db3,
+                                            f"/{endpoint2}/{db2}/{endpoint3}/{db3}",
                                         )
                                     elif (
                                         response.status_code
@@ -1709,31 +1466,11 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                         for db2 in api_test_map[endpoint2]:
                             for db3 in api_test_map[endpoint3]:
                                 for acc1 in api_test_map[endpoint1][db1]:
+                                    # TODO: ❇️ Remember the git stash
                                     # /[endpoint]/[db]/[endpoint]/[db]/[acc]/[endpoint]/[db]
-                                    current = (
-                                        "/api/"
-                                        + endpoint2
-                                        + "/"
-                                        + db2
-                                        + "/"
-                                        + endpoint1
-                                        + "/"
-                                        + db1
-                                        + "/"
-                                        + acc1
-                                        + "/"
-                                        + endpoint3
-                                        + "/"
-                                        + db3
-                                    )
+                                    current = f"/api/{endpoint2}/{db2}/{endpoint1}/{db1}/{acc1}/{endpoint3}/{db3}"
                                     response = self._get_in_debug_mode(current)
                                     if response.status_code == status.HTTP_200_OK:
-                                        key3 = plurals[endpoint3] + "_url"
-                                        self.assertEqual(
-                                            response.status_code,
-                                            status.HTTP_200_OK,
-                                            "URL : [{}]".format(current),
-                                        )
                                         self._check_is_list_of_metadata_objects(
                                             response.data["results"]
                                         )
@@ -1746,25 +1483,34 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 check_coordinates=endpoint1
                                                 != "taxonomy"
                                                 and endpoint1 != "proteome",
-                                                msg="URL : [{}]".format(current),
+                                                msg=f"URL : [{current}]",
                                             )
+                                        key3 = f"{plurals[endpoint3]}_url"
+                                        if endpoint3 not in endpoints_with_url:
+                                            key3 = f"{endpoint3}_subset"
                                         for result in [
                                             x[key3] for x in response.data["results"]
                                         ]:
-                                            self._check_list_of_matches(
-                                                result,
-                                                check_coordinates=endpoint3
-                                                != "taxonomy"
-                                                and endpoint3 != "proteome",
-                                                msg="URL : [{}]".format(current),
-                                            )
+                                            if "_subset" in key3:
+                                                self._check_list_of_matches(
+                                                    result,
+                                                    check_coordinates=endpoint3
+                                                    != "taxonomy"
+                                                    and endpoint3 != "proteome",
+                                                    msg=f"URL : [{current}]",
+                                                )
+                                            else:
+                                                self.asserURL(
+                                                    result,
+                                                    f"The URL in {key3}: {result} is not valid | URL: {current}",
+                                                )
 
                                         self._check_structure_chains_as_filter(
                                             endpoint1,
                                             db1,
                                             acc1,
-                                            endpoint2 + "/" + db2,
-                                            "/" + endpoint3 + "/" + db3,
+                                            f"{endpoint2}/{db2}",
+                                            f"/{endpoint3}/{db3}",
                                             plurals[endpoint1],
                                         )
                                     elif (
@@ -1789,30 +1535,9 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                             for db3 in api_test_map[endpoint3]:
                                 for acc1 in api_test_map[endpoint1][db1]:
                                     # /[endpoint]/[db]/[endpoint]/[db]/[endpoint]/[db]/[acc]
-                                    current = (
-                                        "/api/"
-                                        + endpoint2
-                                        + "/"
-                                        + db2
-                                        + "/"
-                                        + endpoint3
-                                        + "/"
-                                        + db3
-                                        + "/"
-                                        + endpoint1
-                                        + "/"
-                                        + db1
-                                        + "/"
-                                        + acc1
-                                    )
+                                    current = f"/api/{endpoint2}/{db2}/{endpoint3}/{db3}/{endpoint1}/{db1}/{acc1}"
                                     response = self._get_in_debug_mode(current)
                                     if response.status_code == status.HTTP_200_OK:
-                                        key3 = plurals[endpoint3] + "_url"
-                                        self.assertEqual(
-                                            response.status_code,
-                                            status.HTTP_200_OK,
-                                            "URL : [{}]".format(current),
-                                        )
                                         self._check_is_list_of_metadata_objects(
                                             response.data["results"]
                                         )
@@ -1825,29 +1550,33 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 check_coordinates=endpoint1
                                                 != "taxonomy"
                                                 and endpoint1 != "proteome",
-                                                msg="URL : [{}]".format(current),
+                                                msg=f"URL : [{current}]",
                                             )
+                                        key3 = f"{plurals[endpoint3]}_url"
+                                        if endpoint3 not in endpoints_with_url:
+                                            key3 = f"{endpoint3}_subset"
                                         for result in [
                                             x[key3] for x in response.data["results"]
                                         ]:
-                                            self._check_list_of_matches(
-                                                result,
-                                                check_coordinates=endpoint3
-                                                != "taxonomy"
-                                                and endpoint3 != "proteome",
-                                                msg="URL : [{}]".format(current),
-                                            )
+                                            if "_subset" in key3:
+                                                self._check_list_of_matches(
+                                                    result,
+                                                    check_coordinates=endpoint3
+                                                    != "taxonomy"
+                                                    and endpoint3 != "proteome",
+                                                    msg=f"URL : [{current}]",
+                                                )
+                                            else:
+                                                self.asserURL(
+                                                    result,
+                                                    f"The URL in {key3}: {result} is not valid | URL: {current}",
+                                                )
+
                                         self._check_structure_chains_as_filter(
                                             endpoint1,
                                             db1,
                                             acc1,
-                                            endpoint2
-                                            + "/"
-                                            + db2
-                                            + "/"
-                                            + endpoint3
-                                            + "/"
-                                            + db3,
+                                            f"{endpoint2}/{db2}/{endpoint3}/{db3}",
                                             "",
                                             plurals[endpoint1],
                                         )
@@ -1875,31 +1604,13 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                 for acc1 in api_test_map[endpoint1][db1]:
                                     for acc2 in api_test_map[endpoint2][db2]:
                                         # [endpoint]/[db]/[acc]/[endpoint]/[db]/[acc]/[endpoint]/[db]
-                                        current = (
-                                            "/api/"
-                                            + endpoint1
-                                            + "/"
-                                            + db1
-                                            + "/"
-                                            + acc1
-                                            + "/"
-                                            + endpoint2
-                                            + "/"
-                                            + db2
-                                            + "/"
-                                            + acc2
-                                            + "/"
-                                            + endpoint3
-                                            + "/"
-                                            + db3
-                                        )
+                                        current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{acc2}/{endpoint3}/{db3}"
                                         response = self._get_in_debug_mode(current)
                                         if response.status_code == status.HTTP_200_OK:
-                                            key3 = plurals[endpoint3] + "_url"
                                             self.assertEqual(
                                                 response.status_code,
                                                 status.HTTP_200_OK,
-                                                "URL : [{}]".format(current),
+                                                f"URL : [{current}]",
                                             )
                                             self._check_object_by_accesssion(
                                                 response.data
@@ -1909,37 +1620,36 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 check_coordinates=endpoint2
                                                 != "taxonomy"
                                                 and endpoint2 != "proteome",
-                                                msg="URL : [{}]".format(current),
+                                                msg=f"URL : [{current}]",
                                             )
-                                            self._check_list_of_matches(
-                                                response.data[key3],
-                                                check_coordinates=endpoint3
-                                                != "taxonomy"
-                                                and endpoint3 != "proteome",
-                                                msg="URL : [{}]".format(current),
-                                            )
+                                            key3 = f"{plurals[endpoint3]}_url"
+                                            if endpoint3 not in endpoints_with_url:
+                                                key3 = f"{endpoint3}_subset"
+                                                self._check_list_of_matches(
+                                                    response.data[key3],
+                                                    check_coordinates=endpoint3
+                                                    != "taxonomy"
+                                                    and endpoint3 != "proteome",
+                                                    msg=f"URL : [{current}]",
+                                                )
+                                            else:
+                                                self.asserURL(
+                                                    response.data[key3],
+                                                    f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
+                                                )
                                             self._check_structure_and_chains(
                                                 response,
                                                 endpoint1,
                                                 db1,
                                                 acc1,
-                                                "/"
-                                                + endpoint2
-                                                + "/"
-                                                + db2
-                                                + "/"
-                                                + acc2
-                                                + "/"
-                                                + endpoint3
-                                                + "/"
-                                                + db3,
+                                                f"/{endpoint2}/{db2}/{acc2}/{endpoint3}/{db3}",
                                             )
                                             self._check_structure_chains_as_filter(
                                                 endpoint2,
                                                 db2,
                                                 acc2,
-                                                endpoint1 + "/" + db1 + "/" + acc1,
-                                                "/" + endpoint3 + "/" + db3,
+                                                f"{endpoint1}/{db1}/{acc1}",
+                                                f"/{endpoint3}/{db3}",
                                                 plurals[endpoint2],
                                             )
                                         elif (
@@ -1968,11 +1678,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                         current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint3}/{db3}/{endpoint2}/{db2}/{acc2}"
                                         response = self._get_in_debug_mode(current)
                                         if response.status_code == status.HTTP_200_OK:
-                                            key3 = plurals[endpoint3] + "_url"
                                             self.assertEqual(
                                                 response.status_code,
                                                 status.HTTP_200_OK,
-                                                "URL : [{}]".format(current),
+                                                f"URL : [{current}]",
                                             )
                                             self._check_object_by_accesssion(
                                                 response.data
@@ -1982,44 +1691,35 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 check_coordinates=endpoint2
                                                 != "taxonomy"
                                                 and endpoint2 != "proteome",
-                                                msg="URL : [{}]".format(current),
+                                                msg=f"URL : [{current}]",
                                             )
-                                            self._check_list_of_matches(
-                                                response.data[key3],
-                                                check_coordinates=endpoint3
-                                                != "taxonomy"
-                                                and endpoint3 != "proteome",
-                                                msg="URL : [{}]".format(current),
-                                            )
+                                            key3 = f"{plurals[endpoint3]}_url"
+                                            if endpoint3 not in endpoints_with_url:
+                                                key3 = f"{endpoint3}_subset"
+                                                self._check_list_of_matches(
+                                                    response.data[key3],
+                                                    check_coordinates=endpoint3
+                                                    != "taxonomy"
+                                                    and endpoint3 != "proteome",
+                                                    msg=f"URL : [{current}]",
+                                                )
+                                            else:
+                                                self.asserURL(
+                                                    response.data[key3],
+                                                    f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
+                                                )
                                             self._check_structure_and_chains(
                                                 response,
                                                 endpoint1,
                                                 db1,
                                                 acc1,
-                                                "/"
-                                                + endpoint3
-                                                + "/"
-                                                + db3
-                                                + "/"
-                                                + endpoint2
-                                                + "/"
-                                                + db2
-                                                + "/"
-                                                + acc2,
+                                                f"/{endpoint3}/{db3}/{endpoint2}/{db2}/{acc2}",
                                             )
                                             self._check_structure_chains_as_filter(
                                                 endpoint2,
                                                 db2,
                                                 acc2,
-                                                endpoint1
-                                                + "/"
-                                                + db1
-                                                + "/"
-                                                + acc1
-                                                + "/"
-                                                + endpoint3
-                                                + "/"
-                                                + db3,
+                                                f"{endpoint1}/{db1}/{acc1}/{endpoint3}/{db3}",
                                                 "",
                                                 plurals[endpoint2],
                                             )
@@ -2046,30 +1746,13 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                 for acc1 in api_test_map[endpoint1][db1]:
                                     for acc2 in api_test_map[endpoint2][db2]:
                                         # [endpoint]/[db]/[endpoint]/[db]/[acc]/[endpoint]/[db]/[acc]
-                                        current = (
-                                            "/api/"
-                                            + endpoint3
-                                            + "/"
-                                            + db3
-                                            + "/"
-                                            + endpoint1
-                                            + "/"
-                                            + db1
-                                            + "/"
-                                            + acc1
-                                            + "/"
-                                            + endpoint2
-                                            + "/"
-                                            + db2
-                                            + "/"
-                                            + acc2
-                                        )
+                                        current = f"/api/{endpoint3}/{db3}/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{acc2}"
                                         response = self._get_in_debug_mode(current)
                                         if response.status_code == status.HTTP_200_OK:
                                             self.assertEqual(
                                                 response.status_code,
                                                 status.HTTP_200_OK,
-                                                "URL : [{}]".format(current),
+                                                f"URL : [{current}]",
                                             )
                                             self._check_is_list_of_metadata_objects(
                                                 response.data["results"]
@@ -2083,7 +1766,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     check_coordinates=endpoint1
                                                     != "taxonomy"
                                                     and endpoint1 != "proteome",
-                                                    msg="URL : [{}]".format(current),
+                                                    msg=f"URL : [{current}]",
                                                 )
                                             for result in [
                                                 x[plurals[endpoint2]]
@@ -2094,34 +1777,21 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     check_coordinates=endpoint2
                                                     != "taxonomy"
                                                     and endpoint2 != "proteome",
-                                                    msg="URL : [{}]".format(current),
+                                                    msg=f"URL : [{current}]",
                                                 )
                                             self._check_structure_chains_as_filter(
                                                 endpoint1,
                                                 db1,
                                                 acc1,
-                                                endpoint3 + "/" + db3,
-                                                "/"
-                                                + endpoint2
-                                                + "/"
-                                                + db2
-                                                + "/"
-                                                + acc2,
+                                                f"{endpoint3}/{db3}",
+                                                f"/{endpoint2}/{db2}/{acc2}",
                                                 plurals[endpoint1],
                                             )
                                             self._check_structure_chains_as_filter(
                                                 endpoint2,
                                                 db2,
                                                 acc2,
-                                                endpoint3
-                                                + "/"
-                                                + db3
-                                                + "/"
-                                                + endpoint1
-                                                + "/"
-                                                + db1
-                                                + "/"
-                                                + acc1,
+                                                f"{endpoint3}/{db3}/{endpoint1}/{db1}/{acc1}",
                                                 "",
                                                 plurals[endpoint2],
                                             )
@@ -2149,26 +1819,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                     for acc2 in api_test_map[endpoint2][db2]:
                                         # [endpoint]/[db]/[acc]/[endpoint]/[db]/[acc]/[endpoint]/[db]/[acc]
                                         for acc3 in api_test_map[endpoint3][db3]:
-                                            current = (
-                                                "/api/"
-                                                + endpoint1
-                                                + "/"
-                                                + db1
-                                                + "/"
-                                                + acc1
-                                                + "/"
-                                                + endpoint2
-                                                + "/"
-                                                + db2
-                                                + "/"
-                                                + acc2
-                                                + "/"
-                                                + endpoint3
-                                                + "/"
-                                                + db3
-                                                + "/"
-                                                + acc3
-                                            )
+                                            current = f"/api/{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{acc2}/{endpoint3}/{db3}/{acc3}"
                                             response = self._get_in_debug_mode(current)
                                             if (
                                                 response.status_code
@@ -2177,7 +1828,7 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 self.assertEqual(
                                                     response.status_code,
                                                     status.HTTP_200_OK,
-                                                    "URL : [{}]".format(current),
+                                                    f"URL : [{current}]",
                                                 )
                                                 self._check_object_by_accesssion(
                                                     response.data
@@ -2187,61 +1838,35 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                     check_coordinates=endpoint2
                                                     != "taxonomy"
                                                     and endpoint2 != "proteome",
-                                                    msg="URL : [{}]".format(current),
+                                                    msg=f"URL : [{current}]",
                                                 )
                                                 self._check_list_of_matches(
                                                     response.data[plurals[endpoint3]],
                                                     check_coordinates=endpoint3
                                                     != "taxonomy"
                                                     and endpoint3 != "proteome",
-                                                    msg="URL : [{}]".format(current),
+                                                    msg=f"URL : [{current}]",
                                                 )
                                                 self._check_structure_and_chains(
                                                     response,
                                                     endpoint1,
                                                     db1,
                                                     acc1,
-                                                    "/"
-                                                    + endpoint2
-                                                    + "/"
-                                                    + db2
-                                                    + "/"
-                                                    + acc2
-                                                    + "/"
-                                                    + endpoint3
-                                                    + "/"
-                                                    + db3
-                                                    + "/"
-                                                    + acc3,
+                                                    f"/{endpoint2}/{db2}/{acc2}/{endpoint3}/{db3}/{acc3}",
                                                 )
                                                 self._check_structure_chains_as_filter(
                                                     endpoint2,
                                                     db2,
                                                     acc2,
-                                                    endpoint1 + "/" + db1 + "/" + acc1,
-                                                    "/"
-                                                    + endpoint3
-                                                    + "/"
-                                                    + db3
-                                                    + "/"
-                                                    + acc3,
+                                                    f"{endpoint1}/{db1}/{acc1}",
+                                                    f"/{endpoint3}/{db3}/{acc3}",
                                                     plurals[endpoint2],
                                                 )
                                                 self._check_structure_chains_as_filter(
                                                     endpoint3,
                                                     db3,
                                                     acc3,
-                                                    endpoint1
-                                                    + "/"
-                                                    + db1
-                                                    + "/"
-                                                    + acc1
-                                                    + "/"
-                                                    + endpoint2
-                                                    + "/"
-                                                    + db2
-                                                    + "/"
-                                                    + acc2,
+                                                    f"{endpoint1}/{db1}/{acc1}/{endpoint2}/{db2}/{acc2}",
                                                     "",
                                                     plurals[endpoint3],
                                                 )

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -31,7 +31,7 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
-endpoints_with_url = ["entry", "protein", "structure", "proteome", "set"]
+endpoints_with_url = ["entry", "protein", "structure", "taxonomy", "proteome", "set"]
 
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -31,8 +31,6 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
-endpoints_with_url = ["entry", "protein", "structure", "taxonomy", "proteome", "set"]
-
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
     def test_endpoints_independently(self):
@@ -235,26 +233,11 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                 response.data["results"], f"URL : [{current}]"
                             )
                             key2 = f"{plurals[endpoint2]}_url"
-                            if endpoint2 not in endpoints_with_url:
-                                key2 = f"{endpoint2}_subset"
-                                self._check_is_list_of_objects_with_key(
-                                    response.data["results"],
-                                    key2,
-                                    f"URL : [{current}]",
-                                )
                             for result in [x[key2] for x in response.data["results"]]:
-                                if "_subset" in key2:
-                                    self._check_list_of_matches(
-                                        result,
-                                        check_coordinates=endpoint2 != "taxonomy"
-                                        and endpoint2 != "proteome",
-                                        msg=f"URL : [{current}]",
-                                    )
-                                else:
-                                    self.assertURL(
-                                        result,
-                                        f"The URL in {key2}: {result} is not valid | URL: {current}",
-                                    )
+                                self.assertURL(
+                                    result,
+                                    f"The URL in {key2}: {result} is not valid | URL: {current}",
+                                )
 
                         elif response.status_code != status.HTTP_204_NO_CONTENT:
                             self.assertEqual(
@@ -329,28 +312,10 @@ class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):
                                     response.data, f"URL : [{current}]"
                                 )
                                 key = f"{plurals[endpoint2]}_url"
-                                if endpoint2 not in endpoints_with_url:
-                                    key = f"{endpoint2}_subset"
-                                    self._check_list_of_matches(
-                                        response.data[key],
-                                        check_coordinates=endpoint2 != "taxonomy"
-                                        and endpoint2 != "proteome",
-                                        msg=f"URL : [{current}]",
-                                    )
-                                    self._check_structure_and_chains(
-                                        response,
-                                        endpoint1,
-                                        db,
-                                        acc,
-                                        f"/{endpoint2}/{db2}",
-                                        key,
-                                        msg=f"URL : [{current}]",
-                                    )
-                                else:
-                                    self.assertURL(
-                                        response.data[key],
-                                        f"The URL in {key}: {response.data[key]} is not valid | URL: {current}",
-                                    )
+                                self.assertURL(
+                                    response.data[key],
+                                    f"The URL in {key}: {response.data[key]} is not valid | URL: {current}",
+                                )
                             elif response.status_code != status.HTTP_204_NO_CONTENT:
                                 self.assertEqual(
                                     response.status_code, status.HTTP_204_NO_CONTENT
@@ -699,8 +664,6 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                 )
 
                                 key = f"{plurals[endpoint2]}_url"
-                                if endpoint2 not in endpoints_with_url:
-                                    key = f"{endpoint2}_subset"
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     key,
@@ -709,18 +672,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                 for result in [
                                     x[key] for x in response.data["results"]
                                 ]:
-                                    if "_subset" in key:
-                                        self._check_list_of_matches(
-                                            result,
-                                            check_coordinates=endpoint2 != "taxonomy"
-                                            and endpoint2 != "proteome",
-                                            msg=f"URL : [{current}]",
-                                        )
-                                    else:
-                                        self.assertURL(
-                                            result,
-                                            f"The URL in {key}: {result} is not valid | URL: {current}",
-                                        )
+                                    self.assertURL(
+                                        result,
+                                        f"The URL in {key}: {result} is not valid | URL: {current}",
+                                    )
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     plurals[endpoint3],
@@ -752,8 +707,6 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                     f"URL : [{current}]",
                                 )
                                 key2 = f"{plurals[endpoint2]}_url"
-                                if endpoint2 not in endpoints_with_url:
-                                    key2 = f"{endpoint2}_subset"
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     key2,
@@ -762,18 +715,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                 for result in [
                                     x[key2] for x in response.data["results"]
                                 ]:
-                                    if "_subset" in key2:
-                                        self._check_list_of_matches(
-                                            result,
-                                            check_coordinates=endpoint2 != "taxonomy"
-                                            and endpoint2 != "proteome",
-                                            msg=f"URL : [{current}]",
-                                        )
-                                    else:
-                                        self.assertURL(
-                                            result,
-                                            f"The URL in {key2}: {result} is not valid | URL: {current}",
-                                        )
+                                    self.assertURL(
+                                        result,
+                                        f"The URL in {key2}: {result} is not valid | URL: {current}",
+                                    )
                                 self._check_is_list_of_objects_with_key(
                                     response.data["results"],
                                     plurals[endpoint3],
@@ -853,19 +798,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                         response.data, f"URL : [{current}]"
                                     )
                                     key2 = f"{plurals[endpoint2]}_url"
-                                    if endpoint2 not in endpoints_with_url:
-                                        key2 = f"{endpoint2}_subset"
-                                        self._check_list_of_matches(
-                                            response.data[key2],
-                                            check_coordinates=endpoint2 != "taxonomy"
-                                            and endpoint2 != "proteome",
-                                            msg=f"URL : [{current}]",
-                                        )
-                                    else:
-                                        self.assertURL(
-                                            response.data[key2],
-                                            f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
-                                        )
+                                    self.assertURL(
+                                        response.data[key2],
+                                        f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
+                                    )
                                     self._check_counter_by_endpoint(
                                         endpoint3,
                                         response.data,
@@ -907,19 +843,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                         response.data, f"URL : [{current}]"
                                     )
                                     key2 = f"{plurals[endpoint2]}_url"
-                                    if endpoint2 not in endpoints_with_url:
-                                        key2 = f"{endpoint2}_subset"
-                                        self._check_list_of_matches(
-                                            response.data[key2],
-                                            check_coordinates=endpoint2 != "taxonomy"
-                                            and endpoint2 != "proteome",
-                                            msg=f"URL : [{current}]",
-                                        )
-                                    else:
-                                        self.assertURL(
-                                            response.data[key2],
-                                            f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
-                                        )
+                                    self.assertURL(
+                                        response.data[key2],
+                                        f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
+                                    )
                                     self._check_counter_by_endpoint(
                                         endpoint3,
                                         response.data,
@@ -1330,8 +1257,6 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                         f"URL : [{current}]",
                                     )
                                     key2 = f"{plurals[endpoint2]}_url"
-                                    if endpoint2 not in endpoints_with_url:
-                                        key2 = f"{endpoint2}_subset"
                                     self._check_is_list_of_objects_with_key(
                                         response.data["results"],
                                         key2,
@@ -1340,22 +1265,11 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                     for result in [
                                         x[key2] for x in response.data["results"]
                                     ]:
-                                        if "_subset" in key2:
-                                            self._check_list_of_matches(
-                                                result,
-                                                check_coordinates=endpoint2
-                                                != "taxonomy"
-                                                and endpoint2 != "proteome",
-                                                msg=f"URL : [{current}]",
-                                            )
-                                        else:
-                                            self.assertURL(
-                                                result,
-                                                f"The URL in {key2}: {result} is not valid | URL: {current}",
-                                            )
+                                        self.assertURL(
+                                            result,
+                                            f"The URL in {key2}: {result} is not valid | URL: {current}",
+                                        )
                                     key3 = f"{plurals[endpoint3]}_url"
-                                    if endpoint3 not in endpoints_with_url:
-                                        key3 = f"{endpoint3}_subset"
                                     self._check_is_list_of_objects_with_key(
                                         response.data["results"],
                                         key3,
@@ -1364,19 +1278,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                     for result in [
                                         x[key3] for x in response.data["results"]
                                     ]:
-                                        if "_subset" in key3:
-                                            self._check_list_of_matches(
-                                                result,
-                                                check_coordinates=endpoint3
-                                                != "taxonomy"
-                                                and endpoint3 != "proteome",
-                                                msg=f"URL : [{current}]",
-                                            )
-                                        else:
-                                            self.assertURL(
-                                                result,
-                                                f"The URL in {key3}: {result} is not valid | URL: {current}",
-                                            )
+                                        self.assertURL(
+                                            result,
+                                            f"The URL in {key3}: {result} is not valid | URL: {current}",
+                                        )
                                 elif response.status_code != status.HTTP_204_NO_CONTENT:
                                     self.assertEqual(
                                         response.status_code,
@@ -1409,35 +1314,15 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                             response.data, f"URL : [{current}]"
                                         )
                                         key2 = f"{plurals[endpoint2]}_url"
-                                        if endpoint2 not in endpoints_with_url:
-                                            key2 = f"{endpoint2}_subset"
-                                            self._check_list_of_matches(
-                                                response.data[key2],
-                                                check_coordinates=endpoint2
-                                                != "taxonomy"
-                                                and endpoint2 != "proteome",
-                                                msg=f"URL : [{current}]",
-                                            )
-                                        else:
-                                            self.assertURL(
-                                                response.data[key2],
-                                                f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
-                                            )
+                                        self.assertURL(
+                                            response.data[key2],
+                                            f"The URL in {key2}: {response.data[key2]} is not valid | URL: {current}",
+                                        )
                                         key3 = f"{plurals[endpoint3]}_url"
-                                        if endpoint3 not in endpoints_with_url:
-                                            key3 = f"{endpoint3}_subset"
-                                            self._check_list_of_matches(
-                                                response.data[key3],
-                                                check_coordinates=endpoint3
-                                                != "taxonomy"
-                                                and endpoint3 != "proteome",
-                                                msg=f"URL : [{current}]",
-                                            )
-                                        else:
-                                            self.assertURL(
-                                                response.data[key3],
-                                                f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
-                                            )
+                                        self.assertURL(
+                                            response.data[key3],
+                                            f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
+                                        )
                                         self._check_structure_and_chains(
                                             response,
                                             endpoint1,
@@ -1485,24 +1370,13 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                         key3 = f"{plurals[endpoint3]}_url"
-                                        if endpoint3 not in endpoints_with_url:
-                                            key3 = f"{endpoint3}_subset"
                                         for result in [
                                             x[key3] for x in response.data["results"]
                                         ]:
-                                            if "_subset" in key3:
-                                                self._check_list_of_matches(
-                                                    result,
-                                                    check_coordinates=endpoint3
-                                                    != "taxonomy"
-                                                    and endpoint3 != "proteome",
-                                                    msg=f"URL : [{current}]",
-                                                )
-                                            else:
-                                                self.assertURL(
-                                                    result,
-                                                    f"The URL in {key3}: {result} is not valid | URL: {current}",
-                                                )
+                                            self.assertURL(
+                                                result,
+                                                f"The URL in {key3}: {result} is not valid | URL: {current}",
+                                            )
 
                                         self._check_structure_chains_as_filter(
                                             endpoint1,
@@ -1552,24 +1426,13 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                         key3 = f"{plurals[endpoint3]}_url"
-                                        if endpoint3 not in endpoints_with_url:
-                                            key3 = f"{endpoint3}_subset"
                                         for result in [
                                             x[key3] for x in response.data["results"]
                                         ]:
-                                            if "_subset" in key3:
-                                                self._check_list_of_matches(
-                                                    result,
-                                                    check_coordinates=endpoint3
-                                                    != "taxonomy"
-                                                    and endpoint3 != "proteome",
-                                                    msg=f"URL : [{current}]",
-                                                )
-                                            else:
-                                                self.assertURL(
-                                                    result,
-                                                    f"The URL in {key3}: {result} is not valid | URL: {current}",
-                                                )
+                                            self.assertURL(
+                                                result,
+                                                f"The URL in {key3}: {result} is not valid | URL: {current}",
+                                            )
 
                                         self._check_structure_chains_as_filter(
                                             endpoint1,
@@ -1622,20 +1485,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                             key3 = f"{plurals[endpoint3]}_url"
-                                            if endpoint3 not in endpoints_with_url:
-                                                key3 = f"{endpoint3}_subset"
-                                                self._check_list_of_matches(
-                                                    response.data[key3],
-                                                    check_coordinates=endpoint3
-                                                    != "taxonomy"
-                                                    and endpoint3 != "proteome",
-                                                    msg=f"URL : [{current}]",
-                                                )
-                                            else:
-                                                self.assertURL(
-                                                    response.data[key3],
-                                                    f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
-                                                )
+                                            self.assertURL(
+                                                response.data[key3],
+                                                f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
+                                            )
                                             self._check_structure_and_chains(
                                                 response,
                                                 endpoint1,
@@ -1693,20 +1546,10 @@ class ObjectStructureThreeEndpointsTest(InterproRESTTestCase):
                                                 msg=f"URL : [{current}]",
                                             )
                                             key3 = f"{plurals[endpoint3]}_url"
-                                            if endpoint3 not in endpoints_with_url:
-                                                key3 = f"{endpoint3}_subset"
-                                                self._check_list_of_matches(
-                                                    response.data[key3],
-                                                    check_coordinates=endpoint3
-                                                    != "taxonomy"
-                                                    and endpoint3 != "proteome",
-                                                    msg=f"URL : [{current}]",
-                                                )
-                                            else:
-                                                self.assertURL(
-                                                    response.data[key3],
-                                                    f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
-                                                )
+                                            self.assertURL(
+                                                response.data[key3],
+                                                f"The URL in {key3}: {response.data[key3]} is not valid | URL: {current}",
+                                            )
                                             self._check_structure_and_chains(
                                                 response,
                                                 endpoint1,

--- a/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
+++ b/webfront/tests/tests_to_check_the_payload_structure_combining_endpoints.py
@@ -31,7 +31,7 @@ api_test_map = {
 }
 plurals = ModelContentSerializer.plurals
 
-endpoints_with_url = ["entry", "protein"]
+endpoints_with_url = ["entry", "protein", "proteome"]
 
 
 class ObjectStructureTwoEndpointsTest(InterproRESTTestCase):

--- a/webfront/tests/tests_utils.py
+++ b/webfront/tests/tests_utils.py
@@ -7,6 +7,7 @@ from webfront.views.cache import (
     SHOULD_NO_CACHE,
     FIVE_DAYS,
 )
+from webfront.serializers.content_serializers import reverse_url
 
 
 class CanonicalTestCase(TestCase):
@@ -94,3 +95,57 @@ class CacheLifespanTestCase(TestCase):
         for url in urls:
             levels = map_url_to_levels(url.split("?")[0])
             self.assertIsNone(get_timeout_from_path(url, levels))
+
+
+class TestReverseURL(TestCase):
+    def test_reverse_to_entry(self):
+        urls = [
+            [
+                "/protein/uniprot/p99999/entry/InterPro/",
+                "/entry/InterPro/protein/uniprot/p99999/",
+            ],
+            [  # Modifiers are removed
+                "/protein/uniprot/p99999/entry/InterPro/?some-modifier",
+                "/entry/InterPro/protein/uniprot/p99999/",
+            ],
+            [  # 3 endpoints -endpoint
+                "/protein/uniprot/p99999/entry/InterPro/structure",
+                "/entry/InterPro/protein/uniprot/p99999/structure/",
+            ],
+            [  # 3 endpoints - db
+                "/protein/uniprot/p99999/entry/InterPro/structure/pdb",
+                "/entry/InterPro/protein/uniprot/p99999/structure/pdb",
+            ],
+            [  # 3 endpoints - accession
+                "/protein/uniprot/p99999/entry/InterPro/structure/pdb/1cuk",
+                "/entry/InterPro/protein/uniprot/p99999/structure/pdb/1cuk",
+            ],
+        ]
+        for url in urls:
+            self.assertEqual(reverse_url(url[0], "entry"), url[1])
+
+    def test_reverse_to_protein(self):
+        urls = [
+            [
+                "/entry/InterPro/ipr000001/protein/uniprot/",
+                "/protein/uniprot/entry/InterPro/ipr000001/",
+            ],
+            [  # Modifiers are removed
+                "/entry/InterPro/ipr000001/protein/uniprot/?some-modifier",
+                "/protein/uniprot/entry/InterPro/ipr000001/",
+            ],
+            [  # 3 endpoints -endpoint
+                "/entry/InterPro/ipr000001/protein/uniprot/structure",
+                "/protein/uniprot/entry/InterPro/ipr000001/structure/",
+            ],
+            [  # 3 endpoints - db
+                "/entry/InterPro/ipr000001/protein/uniprot/structure/pdb",
+                "/protein/uniprot/entry/InterPro/ipr000001/structure/pdb",
+            ],
+            [  # 3 endpoints - accession
+                "/entry/InterPro/ipr000001/protein/uniprot/structure/pdb/1cuk",
+                "/protein/uniprot/entry/InterPro/ipr000001/structure/pdb/1cuk",
+            ],
+        ]
+        for url in urls:
+            self.assertEqual(reverse_url(url[0], "protein"), url[1])

--- a/webfront/tests/tests_utils.py
+++ b/webfront/tests/tests_utils.py
@@ -122,7 +122,7 @@ class TestReverseURL(TestCase):
             ],
         ]
         for url in urls:
-            self.assertEqual(reverse_url(url[0], "entry"), url[1])
+            self.assertEqual(reverse_url(url[0], "entry", "p99999"), url[1])
 
     def test_reverse_to_protein(self):
         urls = [
@@ -148,4 +148,4 @@ class TestReverseURL(TestCase):
             ],
         ]
         for url in urls:
-            self.assertEqual(reverse_url(url[0], "protein"), url[1])
+            self.assertEqual(reverse_url(url[0], "protein", "ipr000001"), url[1])

--- a/webfront/views/entry.py
+++ b/webfront/views/entry.py
@@ -22,6 +22,7 @@ from webfront.views.modifiers import (
     get_subfamilies,
     mark_as_subfamily,
     get_deprecated_response,
+    show_subset,
 )
 from .custom import CustomView, SerializerDetail
 from django.conf import settings
@@ -208,6 +209,7 @@ class MemberHandler(CustomView):
             type=ModifierType.REPLACE_PAYLOAD,
             many=False,
         )
+        general_handler.modifiers.register("show-subset", show_subset)
 
         return super(MemberHandler, self).get(
             request._request,
@@ -358,6 +360,7 @@ class UnintegratedHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Entry, "counters")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(UnintegratedHandler, self).get(
             request._request,
             endpoint_levels,
@@ -409,6 +412,7 @@ class IntegratedHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Entry, "counters")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(IntegratedHandler, self).get(
             request._request,
             endpoint_levels,
@@ -498,6 +502,7 @@ class InterproHandler(CustomView):
             works_in_multiple_endpoint=False,
         )
         general_handler.modifiers.register("latest_entries", filter_by_latest_entries)
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(InterproHandler, self).get(
             request._request,
             endpoint_levels,
@@ -545,6 +550,7 @@ class AllHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Entry, "counters")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(AllHandler, self).get(
             request._request,
             endpoint_levels,
@@ -658,6 +664,7 @@ class EntryHandler(CustomView):
             type=ModifierType.REPLACE_PAYLOAD,
             serializer=SerializerDetail.IDA_LIST,
         )
+
         response = super(EntryHandler, self).get(
             request._request,
             endpoint_levels,

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -283,8 +283,7 @@ def filter_by_entry_db(value, general_handler):
     return response.first()
 
 
-def filter_by_min_value(endpoint, field, value, sorting_by=[],
-                        sort_pagination=True):
+def filter_by_min_value(endpoint, field, value, sorting_by=[], sort_pagination=True):
     def x(_, general_handler):
         general_handler.queryset_manager.add_filter(
             endpoint, **{"{}__gte".format(field): value}
@@ -880,6 +879,10 @@ def get_subfamilies(value, general_handler):
 
 def mark_as_subfamily(value, general_handler):
     general_handler.queryset_manager.add_filter("entry", is_public=False)
+
+
+def show_subset(value, general_handler):
+    general_handler.queryset_manager.show_subset = True
 
 
 def passing(x, y):

--- a/webfront/views/protein.py
+++ b/webfront/views/protein.py
@@ -18,6 +18,7 @@ from webfront.views.modifiers import (
     calculate_residue_conservation,
     extra_features,
     residues,
+    show_subset,
 )
 from webfront.models import Protein
 from webfront.constants import ModifierType
@@ -185,6 +186,7 @@ class UniprotHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Protein, "counters", "sequence")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(UniprotHandler, self).get(
             request._request,
             endpoint_levels,

--- a/webfront/views/proteome.py
+++ b/webfront/views/proteome.py
@@ -1,7 +1,12 @@
 from webfront.models import Proteome
 from webfront.serializers.proteome import ProteomeSerializer
 from webfront.views.custom import CustomView, SerializerDetail
-from webfront.views.modifiers import group_by, add_extra_fields, filter_by_boolean_field
+from webfront.views.modifiers import (
+    group_by,
+    add_extra_fields,
+    filter_by_boolean_field,
+    show_subset,
+)
 from webfront.constants import ModifierType
 
 
@@ -74,6 +79,7 @@ class UniprotHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Proteome, "counters")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
 
         return super(UniprotHandler, self).get(
             request._request,

--- a/webfront/views/queryset_manager.py
+++ b/webfront/views/queryset_manager.py
@@ -34,6 +34,7 @@ class QuerysetManager:
     order_field = None
     order_field_in_pagination = True
     other_fields = None
+    show_subset = False
 
     def reset_filters(self, endpoint, endpoint_levels=[]):
         self.main_endpoint = endpoint

--- a/webfront/views/set.py
+++ b/webfront/views/set.py
@@ -5,7 +5,12 @@ from webfront.serializers.collection import SetSerializer
 from webfront.views.custom import CustomView, SerializerDetail
 from django.conf import settings
 
-from webfront.views.modifiers import add_extra_fields, get_deprecated_response, sort_by
+from webfront.views.modifiers import (
+    add_extra_fields,
+    get_deprecated_response,
+    sort_by,
+    show_subset,
+)
 
 entry_sets = "|".join(settings.ENTRY_SETS) + "|all"
 entry_sets_accessions = r"^({})$".format(
@@ -92,6 +97,7 @@ class SetTypeHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Set, "counters")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(SetTypeHandler, self).get(
             request._request,
             endpoint_levels,

--- a/webfront/views/structure.py
+++ b/webfront/views/structure.py
@@ -8,6 +8,7 @@ from webfront.views.modifiers import (
     filter_by_field,
     filter_by_field_or_field_range,
     add_extra_fields,
+    show_subset,
 )
 from webfront.constants import ModifierType
 
@@ -128,6 +129,7 @@ class PDBHandler(CustomView):
         general_handler.modifiers.register(
             "extra_fields", add_extra_fields(Structure, "counters")
         )
+        general_handler.modifiers.register("show-subset", show_subset)
         return super(PDBHandler, self).get(
             request._request,
             endpoint_levels,

--- a/webfront/views/taxonomy.py
+++ b/webfront/views/taxonomy.py
@@ -10,6 +10,7 @@ from webfront.views.modifiers import (
     filter_by_domain_architectures,
     add_taxonomy_names,
     get_taxonomy_by_scientific_name,
+    show_subset,
 )
 from webfront.constants import ModifierType
 
@@ -109,6 +110,7 @@ class UniprotHandler(CustomView):
         general_handler.modifiers.register(
             "with_names", add_taxonomy_names, type=ModifierType.EXTEND_PAYLOAD
         )
+        general_handler.modifiers.register("show-subset", show_subset)
 
         return super(UniprotHandler, self).get(
             request._request,


### PR DESCRIPTION
Currently, requests of the types: 
* `[endpont1]/[db1]/[endpont2]/[db2]/`
* `[endpont1]/[db1]/[accession1]/[endpont2]/[db2]/`
include a subset of entities of the `endpoint2`. 

For example:
* `protein_subset` in https://www.ebi.ac.uk/interpro/api/entry/interpro/protein/UniProt/   
* `set_subset` in https://www.ebi.ac.uk/interpro/api/proteome/uniprot/UP000499080/set/pfam

The maximum number of returned entities in a subset is `20` but the actual number could be bigger, and been a list inside a list would require a rather complex nested pagination. This (a) causes confusion and users might believe they got all the info, and (b) makes the responses unnecessarily big.

This PR replaces the `_subset` attributes with `_url`, the URL provided, reverses the order of endpoints to make the main endpoint the one to be listed, which means it could be paginated.

A new URL parameter `show-subset` is now supported on all endpoints, to provide the subsets on-demand, to make it easy to fix for users of that data.

##### To consider
* The generated URL does not consider any URL parameters of the original request, because the API  modifiers are not directly usable among endpoints.
* Before generating the URL, a query is executed in elastic to verify if there are any documents matching both endpoints. The query should be fast, as it doesn't have aggregators and requests 0 documents. 

#### Other changes

I ran [flynt](https://github.com/ikamensh/flynt) on some test files. This replaces old types of Python concatenations with the literal string style. for example:  
* `"foo"+ var` ➡️ `f"foo {var}"`
* `"foo {}". format(var)` ➡️ `f"foo {var}"`

Which is much clearer on those long URLs used in the tests.
---

FIX #134 