### PR TITLE
Fix release notes

### DIFF
--- a/webfront/views/utils.py
+++ b/webfront/views/utils.py
@@ -278,7 +278,8 @@ class ReleaseEndpointHandler(CustomView):
     ):
 
         self.queryset = {
-            note.version: note.release_date for note in Release_Note.objects.all()
+            note.version: note.release_date
+            for note in Release_Note.objects.all().order_by("release_date")
         }
 
         return super(ReleaseEndpointHandler, self).get(

--- a/webfront/views/utils.py
+++ b/webfront/views/utils.py
@@ -260,7 +260,7 @@ class ReleaseVersionEndpointHandler(CustomView):
 class ReleaseEndpointHandler(CustomView):
     level_description = "Release level"
     from_model = False
-    child_handlers = [(r"current|(\d\d\.\d)", ReleaseVersionEndpointHandler)]
+    child_handlers = [(r"current|(\d{2,3}\.\d)", ReleaseVersionEndpointHandler)]
     many = False
     serializer_class = ModelContentSerializer
 


### PR DESCRIPTION
Tiny PR that fixes one bug related to the `/api/utils/release/<version>` endpoint, which currently does not support versions with three digits before the period (so rejects requests starting with InterPro `100.0`).

The PR also "orders" release versions in the payload. The payload is a dictionary where keys are version numbers, so we could argue the order is arbitrary anyway, but since Python 3.7 the dictionary order is guaranteed to be insertion order so the payload of `/api/utils/release/` is more aesthetically pleasing, e.g.

```json
{
    "71.0": "2018-11-08T00:00:00Z",
    "72.0": "2019-01-17T00:00:00Z",
    "73.0": "2019-03-14T00:00:00Z",
    "74.0": "2019-05-09T00:00:00Z",
    "75.0": "2019-07-04T00:00:00Z",
    "76.0": "2019-09-16T00:00:00Z",
    "77.0": "2019-11-14T00:00:00Z",
    "78.0": "2020-02-27T00:00:00Z",
    "78.1": "2020-04-07T20:21:42Z",
    "79.0": "2020-04-23T00:00:00Z",
    "80.0": "2020-06-18T00:00:00Z",
    "81.0": "2020-08-13T00:00:00Z",
    "82.0": "2020-10-08T00:00:00Z",
    "83.0": "2020-12-03T00:00:00Z",
    "84.0": "2021-02-11T00:00:00Z",
    "85.0": "2021-04-08T00:00:00Z",
    "86.0": "2021-06-03T00:00:00Z",
    "87.0": "2021-11-18T00:00:00Z",
    "88.0": "2022-03-10T00:00:00Z",
    "89.0": "2022-05-26T00:00:00Z",
    "90.0": "2022-08-04T00:00:00Z",
    "91.0": "2022-10-13T00:00:00Z",
    "92.0": "2022-12-15T00:00:00Z",
    "93.0": "2023-03-02T00:00:00Z",
    "94.0": "2023-05-10T00:00:00Z",
    "95.0": "2023-06-29T00:00:00Z",
    "96.0": "2023-09-14T00:00:00Z",
    "97.0": "2023-11-09T00:00:00Z",
    "98.0": "2024-01-25T00:00:00Z",
    "99.0": "2024-03-28T00:00:00Z",
    "100.0": "2024-05-30T00:00:00Z",
    "101.0": "2024-07-25T00:00:00Z"
}
```