### PR TITLE
new setting `cache_204`

### DIFF
--- a/config/interpro.yml
+++ b/config/interpro.yml
@@ -13,6 +13,7 @@ url_path_prefix: ""
 use_test_db: false
 enable_caching: false
 enable_cache_write: false
+cache_204: true
 redis: "redis://127.0.0.1:6379/1"
 query_timeout: 60
 cache_volatile_key_ttl: 3600

--- a/webfront/views/common.py
+++ b/webfront/views/common.py
@@ -37,6 +37,7 @@ from time import sleep
 
 QUERY_TIMEOUT = settings.INTERPRO_CONFIG.get("query_timeout", 90)
 CACHE_TIMEOUT = settings.INTERPRO_CONFIG.get("cache_volatile_key_ttl", 1800)
+CACHE_204 = settings.INTERPRO_CONFIG.get("cache_204", True)
 logger = logging.getLogger(__name__)
 
 
@@ -257,7 +258,8 @@ class GeneralHandler(CustomView):
                     raise
                 content = {"detail": e.args[0]}
                 response = Response(content, status=status.HTTP_204_NO_CONTENT)
-                self._set_in_cache(caching_allowed, full_path, response)
+                if CACHE_204:
+                    self._set_in_cache(caching_allowed, full_path, response)
             except DeprecatedModifier as e:
                 content = {"detail": e.args[0]}
                 response = Response(content, status=status.HTTP_410_GONE)


### PR DESCRIPTION
The API caching keeps `204` responses to avoid big recalculations. This however showed to be a bit of an issue, as a user hammered the API on version `100.0` with lots of invalid requests (e.g. `/entry/smart/PF00001`), but because the accession given was valid for a different DB, it was still kept. The cache got full of `204` responses.
This in turn was not cleaned by the cache warming procedure and it was been propagated to the cache in `101.0`.
This PR adds a setting to disable caching of 204 responses. Which I propose to use in the staging machine to avoid propagating `204` responses from one version to the next one.

#### Notice
This only solves the propagation of the `204` responses. But I think a fix on the API is needed to detect these invalid requests in the first place.