### PR TITLE
AI filter for entries

### DIFF
--- a/webfront/views/entry.py
+++ b/webfront/views/entry.py
@@ -195,6 +195,7 @@ class MemberHandler(CustomView):
                     "go_categories": "go_categories",
                     "go_terms": "go_terms",
                     "tax_id": "tax_id",
+                    "ai_categories": "ai_categories"
                 },
             ),
             type=ModifierType.REPLACE_PAYLOAD,
@@ -505,8 +506,6 @@ class InterproHandler(CustomView):
         )
         general_handler.modifiers.register("latest_entries", filter_by_latest_entries)
         
-        # Filter for AI-generated entries, and whether they were reviewed or not
-        general_handler.modifiers.register("ai_category", filter_by_ai_entries)
         
         general_handler.modifiers.register("show-subset", show_subset)
         return super(InterproHandler, self).get(
@@ -661,6 +660,10 @@ class EntryHandler(CustomView):
             "go_term",
             filter_by_contains_field("entry", "go_terms", '"identifier": "{}"'),
         )
+
+        # Filter for AI-generated entries, and whether they were reviewed or not
+        general_handler.modifiers.register("ai_category", filter_by_ai_entries)
+
         general_handler.modifiers.register(
             "annotation", filter_by_contains_field("entry", "entryannotation__type")
         )

--- a/webfront/views/entry.py
+++ b/webfront/views/entry.py
@@ -505,7 +505,7 @@ class InterproHandler(CustomView):
         )
         general_handler.modifiers.register("latest_entries", filter_by_latest_entries)
         
-        # Filter for AI-generated entries, and weather they were reviewed or not
+        # Filter for AI-generated entries, and whether they were reviewed or not
         general_handler.modifiers.register("ai_category", filter_by_ai_entries)
         
         general_handler.modifiers.register("show-subset", show_subset)

--- a/webfront/views/entry.py
+++ b/webfront/views/entry.py
@@ -17,6 +17,7 @@ from webfront.views.modifiers import (
     add_extra_fields,
     ida_search,
     filter_by_latest_entries,
+    filter_by_ai_entries,
     get_value_for_field,
     get_sunburst_taxa,
     get_subfamilies,
@@ -488,6 +489,7 @@ class InterproHandler(CustomView):
                     "member_databases": "",
                     "go_categories": "go_categories",
                     "go_terms": "text",
+                    "ai_categories": "ai_categories"
                 },
             ),
             type=ModifierType.REPLACE_PAYLOAD,
@@ -502,6 +504,10 @@ class InterproHandler(CustomView):
             works_in_multiple_endpoint=False,
         )
         general_handler.modifiers.register("latest_entries", filter_by_latest_entries)
+        
+        # Filter for AI-generated entries, and weather they were reviewed or not
+        general_handler.modifiers.register("ai_category", filter_by_ai_entries)
+        
         general_handler.modifiers.register("show-subset", show_subset)
         return super(InterproHandler, self).get(
             request._request,

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -406,17 +406,6 @@ def filter_by_match_presence(value, general_handler):
         "entry", **{"source_database__isnull": value.lower() != "true"}
     )
 
-""""
-    if is_single_endpoint(general_handler):
-        qs = {
-            groups[cat]: general_handler.queryset_manager.get_queryset()
-            .filter(go_terms__contains=template.format(cat))
-            .count()
-            for cat in groups
-        }
-        return qs"""
-
-
 def filter_by_ai_entries(value, general_handler):
     if value == "MC":
         general_handler.queryset_manager.add_filter("entry", is_llm=False)

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -415,7 +415,6 @@ def filter_by_ai_entries(value, general_handler):
         general_handler.queryset_manager.add_filter("entry", is_llm=True, is_reviewed_llm=False)
 
 def group_by_ai_categories(general_handler):
-    template = '"code": "{}"'
     id_to_params = {
         "MC": {"is_llm": False},
         "AI-R": {"is_llm": True, "is_reviewed_llm": True},


### PR DESCRIPTION
This PR adds support for AI filtering on entries by introducing two modifiers:

- Filtering modifier based on three categories: manually curated, AI-generated reviewed, AI-generated unreviewed;
- Grouping modifier to count how many entries belong to each group.
