### PR TITLE
Check memberDB-accession combination

### DIFF
--- a/webfront/tests/tests_entry_endpoint_protein_filter.py
+++ b/webfront/tests/tests_entry_endpoint_protein_filter.py
@@ -216,12 +216,26 @@ class EntryWithFilterProteinUniprotAccessionRESTTest(InterproRESTTestCase):
                 url, msg=f"The URL [{url}] should've failed."
             )
 
-    def test_urls_that_should_fail(self):
+    def test_urls_with_wrong_accession(self):
         acc = "IPR003165"
         pfam = "PF02171"
         prot = "A1CUJ5"
         tests = [
             f"/api/entry/interpro/{acc}/smart/{pfam}/protein/unreviewed/{prot}",
+            f"/api/structure/PDB/101m/entry/smart/{pfam}",
+            f"/api/entry/smart/{pfam}/structure/PDB/101m/"]
+        for url in tests:
+            self._check_HTTP_response_code(
+                url,
+                code=status.HTTP_404_NOT_FOUND,
+                msg=f"The URL [{url}] should've failed.",
+            )
+        
+    def test_urls_that_should_fail(self):
+        acc = "IPR003165"
+        pfam = "PF02171"
+        prot = "A1CUJ5"
+        tests = [
             f"/api/entry/unintegrated/pfam/{pfam}/protein/unreviewed/{prot}",
         ]
         for url in tests:

--- a/webfront/views/custom.py
+++ b/webfront/views/custom.py
@@ -88,7 +88,7 @@ class CustomView(GenericAPIView):
         for i in range(0, len(endpoint_levels)):
             if (re.match(db_members_accessions, endpoint_levels[i])):
                 if (not(re.match(settings.DB_MEMBERS[endpoint_levels[i-1]]["accession"], endpoint_levels[i]))):
-                    content = {"detail": "The accession provided can't be used for this member database."}
+                    content = {"detail": f"{endpoint_levels[i]} is not a valid {endpoint_levels[i-1].upper()} accession"}
                     return Response(content, status=status.HTTP_404_NOT_FOUND)
 
         # if this is the last level

--- a/webfront/views/custom.py
+++ b/webfront/views/custom.py
@@ -93,7 +93,7 @@ class CustomView(GenericAPIView):
                 # If an accession is found, get the member DB at the previous endpoint level
                 if regex.match(endpoint_level):
                     accession = endpoint_level.upper()
-                    db_key = endpoint_levels[i - 1].lower()
+                    db_key = endpoint_levels[i - 1].lower().replace("tigrfams", "ncbifam")
                     db_member = settings.DB_MEMBERS[db_key]
                     pattern = db_member["accession"]
 


### PR DESCRIPTION
This PR adds a check on any memberDB-accession in the URL.

If any accession provided at endpoint level _X_, doesn't match the regex defined in the [config](https://github.com/ProteinsWebTeam/interpro7-api/blob/master/config/interpro.yml#L27) for the member DB provided at endpoint level _X - 1_, the API returns 404 and and error message.