### PR TITLE
Change Interpro-N match structure

### DIFF
--- a/webfront/models/interpro_new.py
+++ b/webfront/models/interpro_new.py
@@ -295,6 +295,8 @@ class InterProNMatches(models.Model):
     entry = models.ForeignKey(
         Entry, db_column="entry_acc", on_delete=models.SET_NULL, null=True
     )
+    in_interpro = models.BooleanField(db_column="in_interpro", null=False)
+    is_preferred = models.BooleanField(db_column="is_preferred", null=False)
     locations = models.JSONField()
 
     class Meta:

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -925,7 +925,7 @@ def get_interpro_n_matches(value, general_handler):
     for match in ipro_n_matches: 
         integrated = match.entry.integrated
         ipro_n_result[match.entry.pk] = {
-            "accession": match.entry.pk ,
+            "accession": match.entry.pk,
             "name": match.entry.name,
             "type": match.entry.type, 
             "short_name": match.entry.short_name,

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -925,13 +925,22 @@ def get_interpro_n_matches(value, general_handler):
     for match in ipro_n_matches: 
         integrated = match.entry.integrated
         ipro_n_result[match.entry.pk] = {
-            "accession": match.entry.pk,
+            "accession": match.entry.pk ,
             "name": match.entry.name,
             "type": match.entry.type, 
             "short_name": match.entry.short_name,
             "source_database": match.entry.source_database,
-            "integrated": integrated.accession if integrated else None, 
-            "locations": match.locations
+            "integrated": { 
+                "accession": integrated.accession,
+                "name": integrated.name,
+                "source_database": integrated.source_database,
+                "type": integrated.type, 
+                "member_databases": integrated.member_databases,
+                "go_terms":  integrated.go_terms
+             } if integrated else None, 
+            "entry_protein_locations": match.locations,
+            "in_interpro": match.in_interpro,
+            "is_preferred": match.is_preferred
         }
 
     return ipro_n_result

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -919,7 +919,7 @@ def show_subset(value, general_handler):
 def get_interpro_n_matches(value, general_handler):
 
     queryset = general_handler.queryset_manager.get_queryset().first()
-    ipro_n_matches = InterProNMatches.objects.filter(protein_acc=queryset.accession)
+    ipro_n_matches = InterProNMatches.objects.select_related("entry", "entry__integrated").filter(protein_acc=queryset.accession)
     ipro_n_result = {}
 
     for match in ipro_n_matches: 


### PR DESCRIPTION
In this PR the structure of the InterPro-N matches returned by the API has been slightly changed to 
- include the is_preferred boolean and choose the best match on the client;
- return the integrated entry object and not just the accession.