### PR TITLE
TED domains

### DIFF
--- a/webfront/views/cache.py
+++ b/webfront/views/cache.py
@@ -41,6 +41,7 @@ no_cache_modifiers = [
     "subfamily",
     "page_size",
     "ted",
+    "interpro_n",
 ]
 
 

--- a/webfront/views/cache.py
+++ b/webfront/views/cache.py
@@ -40,6 +40,7 @@ no_cache_modifiers = [
     "subfamilies",
     "subfamily",
     "page_size",
+    "ted",
 ]
 
 

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -963,7 +963,6 @@ def get_interpro_n_matches(value, general_handler):
 
 
 def get_ted_domains(value, general_handler):
-    print("yoooo")
     queryset = general_handler.queryset_manager.get_queryset().first()
     url = "https://ted.cathdb.info/api/v1/uniprot/summary/" + queryset.accession
     req = request.Request(

--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -960,7 +960,20 @@ def get_interpro_n_matches(value, general_handler):
         }
 
     return ipro_n_result
-            
+
+
+def get_ted_domains(value, general_handler):
+    print("yoooo")
+    queryset = general_handler.queryset_manager.get_queryset().first()
+    url = "https://ted.cathdb.info/api/v1/uniprot/summary/" + queryset.accession
+    req = request.Request(
+        url=url,
+        headers={"Accept": "application/json"}
+    )
+    with request.urlopen(req) as response:
+        payload = response.read().decode("utf-8")
+
+    return loads(payload)
 
 def passing(x, y):
     pass

--- a/webfront/views/protein.py
+++ b/webfront/views/protein.py
@@ -19,7 +19,8 @@ from webfront.views.modifiers import (
     extra_features,
     residues,
     show_subset,
-    get_interpro_n_matches
+    get_interpro_n_matches,
+    get_ted_domains,
 )
 from webfront.models import Protein
 from webfront.constants import ModifierType
@@ -78,6 +79,10 @@ class UniprotAccessionHandler(CustomView):
         general_handler.modifiers.register(
             "interpro_n", 
             get_interpro_n_matches,
+            type=ModifierType.REPLACE_PAYLOAD)
+        general_handler.modifiers.register(
+            "ted",
+            get_ted_domains,
             type=ModifierType.REPLACE_PAYLOAD)
         
         return super(UniprotAccessionHandler, self).get(


### PR DESCRIPTION
The Encyclopaedia of Domains (TED) provides domains predicted from AlphaFold data.
They have an API (https://ted.cathdb.info/access) we could use on the frontend, but it seems to have CORS restrictions at the moment. I contacted them, but in the meantime, we can use our API as a proxy to query the TED API.

This PR also disable caching InterPro-N data in Redis so we can add new InterPro-N annotations to the data warehouse _after_ building the cache without having to rebuild/clean it.