### PR TITLE
Include InterPro short name for InterPro-N matches

### DIFF
--- a/webfront/views/modifiers.py
+++ b/webfront/views/modifiers.py
@@ -949,6 +949,7 @@ def get_interpro_n_matches(value, general_handler):
             "integrated": { 
                 "accession": integrated.accession,
                 "name": integrated.name,
+                "short_name": integrated.short_name,
                 "source_database": integrated.source_database,
                 "type": integrated.type, 
                 "member_databases": integrated.member_databases,


### PR DESCRIPTION
Fixes (partially) ProteinsWebTeam/interpro7-client#725 by adding `short_name` to the InterPro-N payload.